### PR TITLE
Add Component to Project/Version via Storage Actions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -25,7 +25,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.blackducksoftware.integration:hub-common:23.0.1'
+    compile 'com.blackducksoftware.integration:hub-common:24.0.0'
 
     compile 'org.springframework.boot:spring-boot-starter'
     compile 'org.springframework:spring-web'

--- a/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/HubClient.java
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/HubClient.java
@@ -11,7 +11,7 @@ import org.springframework.stereotype.Component;
 
 import com.blackducksoftware.integration.exception.EncryptionException;
 import com.blackducksoftware.integration.exception.IntegrationException;
-import com.blackducksoftware.integration.hub.api.bom.BomImportRequestService;
+import com.blackducksoftware.integration.hub.api.bom.BomImportService;
 import com.blackducksoftware.integration.hub.artifactory.ArtifactoryRestClient;
 import com.blackducksoftware.integration.hub.artifactory.ConfigurationProperties;
 import com.blackducksoftware.integration.hub.builder.HubServerConfigBuilder;
@@ -52,7 +52,7 @@ public class HubClient {
     }
 
     public void uploadBdioToHub(final File bdioFile) throws IntegrationException {
-        final BomImportRequestService bomImportRequestService = getHubServicesFactory().createBomImportRequestService();
+        final BomImportService bomImportRequestService = getHubServicesFactory().createBomImportService();
         bomImportRequestService.importBomFile(bdioFile);
     }
 

--- a/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/HubProjectDetails.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/HubProjectDetails.groovy
@@ -9,8 +9,8 @@ import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.stereotype.Component
 
-import com.blackducksoftware.integration.hub.api.project.ProjectRequestService
-import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionRequestService
+import com.blackducksoftware.integration.hub.api.project.ProjectService
+import com.blackducksoftware.integration.hub.api.project.version.ProjectVersionService
 import com.blackducksoftware.integration.hub.artifactory.ConfigurationProperties
 import com.blackducksoftware.integration.hub.dataservice.policystatus.PolicyStatusDataService
 import com.blackducksoftware.integration.hub.dataservice.policystatus.PolicyStatusDescription
@@ -64,13 +64,13 @@ class HubProjectDetails {
 
     String getHubProjectVersionUIUrl(String projectName, String projectVersionName){
         HubServicesFactory hubServicesFactory = hubClient.getHubServicesFactory()
-        ProjectRequestService projectRequestService = hubServicesFactory.createProjectRequestService()
-        ProjectVersionRequestService projectVersionRequestService = hubServicesFactory.createProjectVersionRequestService()
+        ProjectService projectService = hubServicesFactory.createProjectService()
+        ProjectVersionService projectVersionService = hubServicesFactory.createProjectVersionService()
         HubServerConfig hubServerConfig = hubClient.createBuilder().build()
 
-        ProjectView project = projectRequestService.getProjectByName(projectName)
-        ProjectVersionView projectVersion = projectVersionRequestService.getProjectVersion(project, projectVersionName)
-        String projectVersionUIUrl = projectRequestService.getFirstLinkSafely(projectVersion, "components")
+        ProjectView project = projectService.getProjectByName(projectName)
+        ProjectVersionView projectVersion = projectVersionService.getProjectVersion(project, projectVersionName)
+        String projectVersionUIUrl = projectService.getFirstLinkSafely(projectVersion, "components")
         projectVersionUIUrl
     }
 }

--- a/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/blackDuckCacheInspector.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/blackDuckCacheInspector.groovy
@@ -4,6 +4,7 @@ import org.artifactory.fs.FileLayoutInfo
 import org.artifactory.fs.ItemInfo
 import org.artifactory.md.Properties
 import org.artifactory.repo.RepoPath
+import org.artifactory.repo.RepoPathFactory
 import org.artifactory.repo.RepositoryConfiguration
 
 import com.blackducksoftware.integration.hub.api.bom.BomImportRequestService
@@ -65,6 +66,16 @@ executions {
 
         updateFromHubProject(repoKey, projectName, projectVersionName);
     }
+
+    test(httpMethod: 'POST') { params ->
+        def repoKey = params['repoKey'][0]
+
+        message = ''
+        message += repositories.getProperty(repoKey, 'blackduck.projectName')
+        message += '\n'
+        message += repositories.getProperty(repoKey, 'blackduck.projectVersionName')
+        message += '\n'
+    }
 }
 
 storage {
@@ -73,6 +84,8 @@ storage {
             SimpleBdioFactory simpleBdioFactory = new SimpleBdioFactory()
             RepoPath repoPath = item.getRepoPath()
             String repoKey = item.getRepoKey()
+            String projectName = repositories.getProperty(RepoPathFactory.create(repoKey, '/'), 'blackduck.projectName')
+            String projectVersionName = repositories.getProperty(RepoPathFactory.create(repoKey, '/'), 'blackduck.projectVersionName')
             String packageType = repositories.getRepositoryConfiguration(repoKey).getPackageType()
             Dependency repoPathDependency = createDependency(simpleBdioFactory, repoPath, packageType)
             if (repoPathDependency != null) {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/blackDuckCacheInspector.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/inspect/blackDuckCacheInspector.groovy
@@ -66,16 +66,6 @@ executions {
 
         updateFromHubProject(repoKey, projectName, projectVersionName);
     }
-
-    test(httpMethod: 'POST') { params ->
-        def repoKey = params['repoKey'][0]
-
-        message = ''
-        message += repositories.getProperty(repoKey, 'blackduck.projectName')
-        message += '\n'
-        message += repositories.getProperty(repoKey, 'blackduck.projectVersionName')
-        message += '\n'
-    }
 }
 
 storage {

--- a/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/scan/blackDuckScanForHub.groovy
+++ b/src/main/groovy/com/blackducksoftware/integration/hub/artifactory/scan/blackDuckScanForHub.groovy
@@ -34,7 +34,7 @@ import org.joda.time.DateTime
 import org.joda.time.DateTimeZone
 import org.joda.time.format.DateTimeFormat
 
-import com.blackducksoftware.integration.hub.api.item.MetaService
+import com.blackducksoftware.integration.hub.api.view.MetaHandler
 import com.blackducksoftware.integration.hub.builder.HubScanConfigBuilder
 import com.blackducksoftware.integration.hub.builder.HubServerConfigBuilder
 import com.blackducksoftware.integration.hub.dataservice.cli.CLIDataService
@@ -48,7 +48,7 @@ import com.blackducksoftware.integration.hub.model.view.VersionBomPolicyStatusVi
 import com.blackducksoftware.integration.hub.request.builder.ProjectRequestBuilder
 import com.blackducksoftware.integration.hub.rest.CredentialsRestConnection
 import com.blackducksoftware.integration.hub.scan.HubScanConfig
-import com.blackducksoftware.integration.hub.service.HubResponseService
+import com.blackducksoftware.integration.hub.service.HubService
 import com.blackducksoftware.integration.hub.service.HubServicesFactory
 import com.blackducksoftware.integration.hub.util.ProjectNameVersionGuess
 import com.blackducksoftware.integration.hub.util.ProjectNameVersionGuesser
@@ -255,9 +255,9 @@ jobs {
 
         Set<RepoPath> repoPaths = searchForRepoPaths()
         HubServicesFactory hubServicesFactory = createHubServicesFactory()
-        HubResponseService hubResponseService = hubServicesFactory.createHubResponseService()
+        HubService hubService = hubServicesFactory.createHubService()
 
-        populatePolicyStatuses(hubResponseService, repoPaths)
+        populatePolicyStatuses(hubService, repoPaths)
 
         log.info('...completed blackDuckAddPolicyStatus cron job.')
     }
@@ -435,7 +435,7 @@ private void deletePathArtifact(String fileName){
 
 private void writeScanProperties(RepoPath repoPath, ProjectVersionView projectVersionView){
     HubServicesFactory hubServicesFactory = createHubServicesFactory()
-    HubResponseService hubResponseService = hubServicesFactory.createHubResponseService()
+    HubService hubResponseService = hubServicesFactory.createHubService()
     log.info("${repoPath.name} was successfully scanned by the BlackDuck CLI.")
     repositories.setProperty(repoPath, BLACK_DUCK_SCAN_RESULT_PROPERTY_NAME, 'SUCCESS')
 
@@ -461,7 +461,7 @@ private void writeScanProperties(RepoPath repoPath, ProjectVersionView projectVe
     }
 }
 
-private void populatePolicyStatuses(HubResponseService hubResponseService, Set<RepoPath> repoPaths) {
+private void populatePolicyStatuses(HubService hubResponseService, Set<RepoPath> repoPaths) {
     boolean problemRetrievingPolicyStatus = false
     repoPaths.each {
         try {
@@ -469,11 +469,11 @@ private void populatePolicyStatuses(HubResponseService hubResponseService, Set<R
             if (StringUtils.isNotBlank(projectVersionUrl)) {
                 projectVersionUrl = updateUrlPropertyToCurrentHubServer(projectVersionUrl)
                 repositories.setProperty(it, BLACK_DUCK_PROJECT_VERSION_URL_PROPERTY_NAME, projectVersionUrl)
-                ProjectVersionView projectVersionView = hubResponseService.getItem(projectVersionUrl, ProjectVersionView.class)
+                ProjectVersionView projectVersionView = hubResponseService.getView(projectVersionUrl, ProjectVersionView.class)
                 try{
-                    String policyStatusUrl = hubResponseService.getFirstLink(projectVersionView, MetaService.POLICY_STATUS_LINK)
+                    String policyStatusUrl = hubResponseService.getFirstLink(projectVersionView, MetaHandler.POLICY_STATUS_LINK)
                     log.info("Looking up policy status: ${policyStatusUrl}")
-                    VersionBomPolicyStatusView versionBomPolicyStatusView = hubResponseService.getItem(policyStatusUrl, VersionBomPolicyStatusView.class)
+                    VersionBomPolicyStatusView versionBomPolicyStatusView = hubResponseService.getView(policyStatusUrl, VersionBomPolicyStatusView.class)
                     log.info("policy status json: ${versionBomPolicyStatusView.json}")
                     PolicyStatusDescription policyStatusDescription = new PolicyStatusDescription(versionBomPolicyStatusView)
                     repositories.setProperty(it, BLACK_DUCK_POLICY_STATUS_PROPERTY_NAME, policyStatusDescription.policyStatusMessage)


### PR DESCRIPTION
Use the Hub 4.2 addBomComponent endpoint to add new components to a project/version in the hub, triggered by the artifactory storage actions on the component being created.