### PR TITLE
Composer fix

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
@@ -32,6 +32,8 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.Inspect
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.ArtifactoryInfoExternalIdExtractor;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.ExternalIdService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.ComposerExternalIdExtractor;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.ComposerJsonService;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.ComposerVersionSelector;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.conda.CondaExternalIdExtractor;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ArtifactNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.PolicyNotificationService;
@@ -153,7 +155,9 @@ public class ModuleFactory {
         BlackDuckBOMService blackDuckBOMService = new BlackDuckBOMService(projectBomService, componentService, blackDuckApiClient);
 
         ArtifactoryInfoExternalIdExtractor artifactoryInfoExternalIdExtractor = new ArtifactoryInfoExternalIdExtractor(artifactoryPAPIService, externalIdFactory);
-        ComposerExternalIdExtractor composerExternalIdExtractor = new ComposerExternalIdExtractor(artifactSearchService, artifactoryPAPIService, externalIdFactory, gson);
+        ComposerVersionSelector composerVersionSelector = new ComposerVersionSelector(externalIdFactory);
+        ComposerJsonService composerJsonService = new ComposerJsonService(artifactoryPAPIService, gson);
+        ComposerExternalIdExtractor composerExternalIdExtractor = new ComposerExternalIdExtractor(composerVersionSelector, composerJsonService);
         CondaExternalIdExtractor condaExternalIdExtractor = new CondaExternalIdExtractor(externalIdFactory);
         ExternalIdService externalIdService = new ExternalIdService(artifactoryPAPIService, artifactoryInfoExternalIdExtractor, composerExternalIdExtractor, condaExternalIdExtractor);
         ArtifactoryComponentService artifactoryComponentService = new ArtifactoryComponentService(blackDuckServicesFactory.getRequestFactory(), blackDuckApiClient);

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractor.java
@@ -7,139 +7,38 @@
  */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
 
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.IntStream;
 
-import org.apache.commons.lang3.StringUtils;
 import org.artifactory.repo.RepoPath;
-import org.artifactory.resource.ResourceStreamHandle;
 
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonParser;
-import com.synopsys.integration.bdio.model.Forge;
 import com.synopsys.integration.bdio.model.externalid.ExternalId;
-import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
-import com.synopsys.integration.blackduck.artifactory.ArtifactSearchService;
-import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerJsonResult;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerVersion;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.SupportedPackageType;
 
 public class ComposerExternalIdExtractor {
-    private final ArtifactSearchService artifactSearchService;
-    private final ArtifactoryPAPIService artifactoryPAPIService;
-    private final ExternalIdFactory externalIdFactory;
-    private final Gson gson;
+    private final ComposerVersionSelector composerVersionSelector;
+    private final ComposerJsonService composerJsonService;
 
-    public ComposerExternalIdExtractor(ArtifactSearchService artifactSearchService, ArtifactoryPAPIService artifactoryPAPIService, ExternalIdFactory externalIdFactory, Gson gson) {
-        this.artifactSearchService = artifactSearchService;
-        this.artifactoryPAPIService = artifactoryPAPIService;
-        this.externalIdFactory = externalIdFactory;
-        this.gson = gson;
+    public ComposerExternalIdExtractor(ComposerVersionSelector composerVersionSelector, ComposerJsonService composerJsonService) {
+        this.composerVersionSelector = composerVersionSelector;
+        this.composerJsonService = composerJsonService;
     }
 
     public Optional<ExternalId> extractExternalId(SupportedPackageType supportedPackageType, RepoPath repoPath) {
-        FileNamePieces fileNamePieces = extractFileNamePieces(repoPath);
-        String jsonFileName = fileNamePieces.getComponentName().toLowerCase() + ".json";
-        List<RepoPath> jsonFileRepoPaths = artifactSearchService.findArtifactByName(jsonFileName, repoPath.getRepoKey());
+        ComposerJsonResult composerJsonResult = composerJsonService.findJsonFiles(repoPath);
 
-        ExternalId externalId = null;
-        for (RepoPath jsonFileRepoPath : jsonFileRepoPaths) {
-            List<ComposerVersion> composerVersions = parseJson(jsonFileRepoPath);
-            List<ExternalId> externalIds = new ArrayList<>();
-
-            for (ComposerVersion composerVersion : composerVersions) {
-                String referenceHash = composerVersion.getVersionSource().getReference();
-                String artifactHash = fileNamePieces.getHash();
-                if (referenceHash.equals(artifactHash)) {
-                    Forge forge = supportedPackageType.getForge();
-                    ExternalId foundExternalId = externalIdFactory.createNameVersionExternalId(forge, composerVersion.getName(), composerVersion.getVersion());
-                    externalIds.add(foundExternalId);
-                }
-            }
-
-            // Try to find an external id that contains version numbers since dev releases can also be in this list.
-            for (ExternalId foundExternalId : externalIds) {
-                String[] numbers = IntStream.rangeClosed(0, 9)
-                                       .boxed()
-                                       .map(String::valueOf)
-                                       .toArray(String[]::new);
-                if (StringUtils.containsAny(foundExternalId.getVersion(), numbers) || externalId == null) {
-                    externalId = foundExternalId;
-                }
-
-            }
-
-            if (externalId != null) {
+        ExternalId extractedExternalId = null;
+        for (RepoPath jsonFileRepoPath : composerJsonResult.getRepoPaths()) {
+            List<ComposerVersion> composerVersions = composerJsonService.parseJson(jsonFileRepoPath);
+            extractedExternalId = composerVersionSelector.discoverMatchingVersion(supportedPackageType, composerJsonResult.getFileNamePieces().getHash(), composerVersions)
+                                      .orElse(null);
+            if (extractedExternalId != null) {
                 break;
             }
         }
 
-        return Optional.ofNullable(externalId);
-    }
-
-    private List<ComposerVersion> parseJson(RepoPath repoPath) {
-        try (ResourceStreamHandle resourceStreamHandle = artifactoryPAPIService.getArtifactContent(repoPath)) {
-            InputStream inputStream = resourceStreamHandle.getInputStream();
-            InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
-            JsonElement root = JsonParser.parseReader(inputStreamReader);
-            Set<Map.Entry<String, JsonElement>> rootEntries = root.getAsJsonObject().get("packages").getAsJsonObject().entrySet();
-            List<ComposerVersion> composerVersions = new ArrayList<>();
-            for (Map.Entry<String, JsonElement> rootEntry : rootEntries) {
-                Set<Map.Entry<String, JsonElement>> versionJsonElements = rootEntry.getValue().getAsJsonObject().entrySet();
-
-                for (Map.Entry<String, JsonElement> versionJsonElement : versionJsonElements) {
-                    ComposerVersion composerVersion = gson.fromJson(versionJsonElement.getValue(), ComposerVersion.class);
-                    composerVersions.add(composerVersion);
-                }
-            }
-
-            return composerVersions;
-        }
-    }
-
-    private FileNamePieces extractFileNamePieces(RepoPath repoPath) {
-        String fullFileName = repoPath.getName();
-        String[] zipExtensionPieces = fullFileName.split("\\.");
-        String extension = zipExtensionPieces[zipExtensionPieces.length - 1];
-        int extensionStart = fullFileName.indexOf(extension) - 1;
-        String extensionRemovedFileName = fullFileName.substring(0, extensionStart);
-
-        String[] componentNameHashPieces = extensionRemovedFileName.split("-");
-        String hash = componentNameHashPieces[componentNameHashPieces.length - 1];
-        int hashStart = extensionRemovedFileName.indexOf(hash) - 1;
-        String componentName = extensionRemovedFileName.substring(0, hashStart).toLowerCase();
-
-        return new FileNamePieces(componentName, hash, extension);
-    }
-
-    private class FileNamePieces {
-        private final String componentName;
-        private final String hash;
-        private final String extension;
-
-        private FileNamePieces(String componentName, String hash, String extension) {
-            this.componentName = componentName;
-            this.hash = hash;
-            this.extension = extension;
-        }
-
-        public String getComponentName() {
-            return componentName;
-        }
-
-        public String getHash() {
-            return hash;
-        }
-
-        public String getExtension() {
-            return extension;
-        }
+        return Optional.ofNullable(extractedExternalId);
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
@@ -61,6 +61,7 @@ public class ComposerJsonService {
         }
     }
 
+    // TODO: Create a generic filename pieces extractor. - JakeMathews 04/2021
     private FileNamePieces extractFileNamePieces(RepoPath repoPath) {
         String fullFileName = repoPath.getName();
         String[] zipExtensionPieces = fullFileName.split("\\.");

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
@@ -9,16 +9,17 @@ package com.synopsys.integration.blackduck.artifactory.modules.inspection.extern
 
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import org.artifactory.repo.RepoPath;
 import org.artifactory.resource.ResourceStreamHandle;
 
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerJsonResult;
@@ -46,19 +47,19 @@ public class ComposerJsonService {
             InputStream inputStream = resourceStreamHandle.getInputStream();
             InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
             JsonElement root = JsonParser.parseReader(inputStreamReader);
-            Set<Map.Entry<String, JsonElement>> rootEntries = root.getAsJsonObject().get("packages").getAsJsonObject().entrySet();
-            List<ComposerVersion> composerVersions = new ArrayList<>();
-            for (Map.Entry<String, JsonElement> rootEntry : rootEntries) {
-                Set<Map.Entry<String, JsonElement>> versionJsonElements = rootEntry.getValue().getAsJsonObject().entrySet();
 
-                for (Map.Entry<String, JsonElement> versionJsonElement : versionJsonElements) {
-                    ComposerVersion composerVersion = gson.fromJson(versionJsonElement.getValue(), ComposerVersion.class);
-                    composerVersions.add(composerVersion);
-                }
-            }
-
-            return composerVersions;
+            return streamChildren(root.getAsJsonObject().get("packages"))
+                       .flatMap(this::streamChildren)
+                       .map(version -> gson.fromJson(version, ComposerVersion.class))
+                       .collect(Collectors.toList());
         }
+    }
+
+    private Stream<JsonElement> streamChildren(JsonElement rootEntries) {
+        JsonObject rootObject = rootEntries.getAsJsonObject();
+        return rootObject.entrySet()
+                   .stream()
+                   .map(Map.Entry::getValue);
     }
 
     // TODO: Create a generic filename pieces extractor. - JakeMathews 04/2021

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
@@ -1,0 +1,71 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
+
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.artifactory.repo.RepoPath;
+import org.artifactory.resource.ResourceStreamHandle;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerJsonResult;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerVersion;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.FileNamePieces;
+
+public class ComposerJsonService {
+    private final ArtifactoryPAPIService artifactoryPAPIService;
+    private final Gson gson;
+
+    public ComposerJsonService(ArtifactoryPAPIService artifactoryPAPIService, Gson gson) {
+        this.artifactoryPAPIService = artifactoryPAPIService;
+        this.gson = gson;
+    }
+
+    public ComposerJsonResult findJsonFiles(RepoPath repoPath) {
+        FileNamePieces fileNamePieces = extractFileNamePieces(repoPath);
+        String jsonFileName = fileNamePieces.getComponentName().toLowerCase() + ".json";
+        List<RepoPath> foundArtifacts = artifactoryPAPIService.itemsByName(jsonFileName, repoPath.getRepoKey());
+        return new ComposerJsonResult(fileNamePieces, foundArtifacts);
+    }
+
+    public List<ComposerVersion> parseJson(RepoPath repoPath) {
+        try (ResourceStreamHandle resourceStreamHandle = artifactoryPAPIService.getArtifactContent(repoPath)) {
+            InputStream inputStream = resourceStreamHandle.getInputStream();
+            InputStreamReader inputStreamReader = new InputStreamReader(inputStream);
+            JsonElement root = JsonParser.parseReader(inputStreamReader);
+            Set<Map.Entry<String, JsonElement>> rootEntries = root.getAsJsonObject().get("packages").getAsJsonObject().entrySet();
+            List<ComposerVersion> composerVersions = new ArrayList<>();
+            for (Map.Entry<String, JsonElement> rootEntry : rootEntries) {
+                Set<Map.Entry<String, JsonElement>> versionJsonElements = rootEntry.getValue().getAsJsonObject().entrySet();
+
+                for (Map.Entry<String, JsonElement> versionJsonElement : versionJsonElements) {
+                    ComposerVersion composerVersion = gson.fromJson(versionJsonElement.getValue(), ComposerVersion.class);
+                    composerVersions.add(composerVersion);
+                }
+            }
+
+            return composerVersions;
+        }
+    }
+
+    private FileNamePieces extractFileNamePieces(RepoPath repoPath) {
+        String fullFileName = repoPath.getName();
+        String[] zipExtensionPieces = fullFileName.split("\\.");
+        String extension = zipExtensionPieces[zipExtensionPieces.length - 1];
+        int extensionStart = fullFileName.indexOf(extension) - 1;
+        String extensionRemovedFileName = fullFileName.substring(0, extensionStart);
+
+        String[] componentNameHashPieces = extensionRemovedFileName.split("-");
+        String hash = componentNameHashPieces[componentNameHashPieces.length - 1];
+        int hashStart = extensionRemovedFileName.indexOf(hash) - 1;
+        String componentName = extensionRemovedFileName.substring(0, hashStart).toLowerCase();
+
+        return new FileNamePieces(componentName, hash, extension);
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonService.java
@@ -1,3 +1,10 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
 
 import java.io.InputStream;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelector.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelector.java
@@ -11,7 +11,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.IntStream;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
@@ -48,11 +47,8 @@ public class ComposerVersionSelector {
         // Try to find an external id that contains version numbers since dev releases can also be in this list.
         ExternalId decidedExternalId = null;
         for (ExternalId foundExternalId : externalIdsMatchingHash) {
-            String[] numbers = IntStream.rangeClosed(0, 9)
-                                   .boxed()
-                                   .map(String::valueOf)
-                                   .toArray(String[]::new);
-            boolean containsNumbers = StringUtils.containsAny(foundExternalId.getVersion(), numbers);
+            boolean containsNumbers = foundExternalId.getVersion().chars()
+                                          .anyMatch(Character::isDigit);
             boolean containsDev = foundExternalId.getVersion().contains("dev");
             if ((!containsDev && containsNumbers) || decidedExternalId == null) {
                 decidedExternalId = foundExternalId;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelector.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelector.java
@@ -1,0 +1,67 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.IntStream;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.bdio.model.externalid.ExternalId;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerVersion;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.SupportedPackageType;
+
+public class ComposerVersionSelector {
+    private final Logger logger = LoggerFactory.getLogger(getClass());
+
+    private final ExternalIdFactory externalIdFactory;
+
+    public ComposerVersionSelector(ExternalIdFactory externalIdFactory) {
+        this.externalIdFactory = externalIdFactory;
+    }
+
+    public Optional<ExternalId> discoverMatchingVersion(SupportedPackageType supportedPackageType, String artifactHash, Collection<ComposerVersion> composerVersions) {
+        Forge forge = supportedPackageType.getForge();
+
+        List<ExternalId> externalIdsMatchingHash = new ArrayList<>();
+        for (ComposerVersion composerVersion : composerVersions) {
+            String referenceHash = composerVersion.getVersionSource().getReference();
+            if (referenceHash.equals(artifactHash)) {
+
+                ExternalId foundExternalId = externalIdFactory.createNameVersionExternalId(forge, composerVersion.getName(), composerVersion.getVersion());
+                externalIdsMatchingHash.add(foundExternalId);
+            }
+        }
+
+        // Try to find an external id that contains version numbers since dev releases can also be in this list.
+        ExternalId decidedExternalId = null;
+        for (ExternalId foundExternalId : externalIdsMatchingHash) {
+            String[] numbers = IntStream.rangeClosed(0, 9)
+                                   .boxed()
+                                   .map(String::valueOf)
+                                   .toArray(String[]::new);
+            boolean containsNumbers = StringUtils.containsAny(foundExternalId.getVersion(), numbers);
+            boolean containsDev = foundExternalId.getVersion().contains("dev");
+            if ((!containsDev && containsNumbers) || decidedExternalId == null) {
+                decidedExternalId = foundExternalId;
+            } else {
+                String externalId = StringUtils.join(forge.getName(), forge.getSeparator(), foundExternalId.createExternalId());
+                logger.debug("Excluding potential match for composer artifact hash {}. ExternalId: {}", artifactHash, externalId);
+            }
+        }
+
+        return Optional.ofNullable(decidedExternalId);
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/ComposerJsonResult.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/ComposerJsonResult.java
@@ -1,0 +1,23 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model;
+
+import java.util.List;
+
+import org.artifactory.repo.RepoPath;
+
+public class ComposerJsonResult {
+    private final FileNamePieces fileNamePieces;
+    private final List<RepoPath> repoPaths;
+
+    public ComposerJsonResult(FileNamePieces fileNamePieces, List<RepoPath> repoPaths) {
+        this.fileNamePieces = fileNamePieces;
+        this.repoPaths = repoPaths;
+    }
+
+    public FileNamePieces getFileNamePieces() {
+        return fileNamePieces;
+    }
+
+    public List<RepoPath> getRepoPaths() {
+        return repoPaths;
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/ComposerJsonResult.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/ComposerJsonResult.java
@@ -1,3 +1,10 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model;
 
 import java.util.List;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/FileNamePieces.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/FileNamePieces.java
@@ -1,3 +1,10 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model;
 
 public class FileNamePieces {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/FileNamePieces.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/FileNamePieces.java
@@ -1,0 +1,25 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model;
+
+public class FileNamePieces {
+    private final String componentName;
+    private final String hash;
+    private final String extension;
+
+    public FileNamePieces(String componentName, String hash, String extension) {
+        this.componentName = componentName;
+        this.hash = hash;
+        this.extension = extension;
+    }
+
+    public String getComponentName() {
+        return componentName;
+    }
+
+    public String getHash() {
+        return hash;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/VersionSource.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/model/VersionSource.java
@@ -11,7 +11,7 @@ import com.google.gson.annotations.SerializedName;
 
 public class VersionSource {
     @SerializedName("reference")
-    private String reference;
+    public String reference;
 
     public String getReference() {
         return reference;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/BlackDuckBOMService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/BlackDuckBOMService.java
@@ -74,15 +74,15 @@ public class BlackDuckBOMService {
     // Mostly copied from the ProjectBomService in blackduck-common. Made tweaks so the component that was attempting to be added is always returned.
     private ComponentViewWrapper addComponentToProjectVersion(RepoPath repoPath, ExternalId componentExternalId, ProjectVersionView projectVersionView) throws IntegrationException {
         ComponentViewWrapper componentViewWrapper;
-
+        String externalIdString = String.format("%s:%s", componentExternalId.getForge().toString(), componentExternalId.createExternalId());
         Optional<ComponentsView> componentsView = componentService.getFirstOrEmptyResult(componentExternalId);
         if (!componentsView.isPresent()) {
-            throw new FailedInspectionException(repoPath, String.format("Failed to find component match for component %s.", componentExternalId.toString()));
+            throw new FailedInspectionException(repoPath, String.format("Failed to find component match for component '%s'.", externalIdString));
         }
 
         Optional<ComponentVersionView> componentVersionView = componentService.getComponentVersionView(componentsView.get());
         if (!componentVersionView.isPresent()) {
-            throw new FailedInspectionException(repoPath, String.format("Failed to find component version for component %s.", componentExternalId.toString()));
+            throw new FailedInspectionException(repoPath, String.format("Failed to find component version for component '%s'.", externalIdString));
         }
 
         try {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/BlackDuckBOMService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/BlackDuckBOMService.java
@@ -49,8 +49,9 @@ public class BlackDuckBOMService {
         RepoPath repoPath = artifact.getRepoPath();
         ComponentViewWrapper componentViewWrapper;
 
-        if (artifact.getExternalId().isPresent()) {
-            ExternalId externalId = artifact.getExternalId().get();
+        Optional<ExternalId> externalIdOptional = artifact.getExternalId();
+        if (externalIdOptional.isPresent()) {
+            ExternalId externalId = externalIdOptional.get();
             try {
                 componentViewWrapper = addComponentToProjectVersion(repoPath, externalId, projectVersionView);
             } catch (BlackDuckIntegrationException e) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/BlackDuckBOMService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/BlackDuckBOMService.java
@@ -76,24 +76,20 @@ public class BlackDuckBOMService {
     private ComponentViewWrapper addComponentToProjectVersion(RepoPath repoPath, ExternalId componentExternalId, ProjectVersionView projectVersionView) throws IntegrationException {
         ComponentViewWrapper componentViewWrapper;
         String externalIdString = String.format("%s:%s", componentExternalId.getForge().toString(), componentExternalId.createExternalId());
-        Optional<ComponentsView> componentsView = componentService.getFirstOrEmptyResult(componentExternalId);
-        if (!componentsView.isPresent()) {
-            throw new FailedInspectionException(repoPath, String.format("Failed to find component match for component '%s'.", externalIdString));
-        }
+        ComponentsView componentsView = componentService.getFirstOrEmptyResult(componentExternalId)
+                                            .orElseThrow(() -> new FailedInspectionException(repoPath, String.format("Failed to find component match for component '%s'.", externalIdString)));
 
-        Optional<ComponentVersionView> componentVersionView = componentService.getComponentVersionView(componentsView.get());
-        if (!componentVersionView.isPresent()) {
-            throw new FailedInspectionException(repoPath, String.format("Failed to find component version for component '%s'.", externalIdString));
-        }
+        ComponentVersionView componentVersionView = componentService.getComponentVersionView(componentsView)
+                                                        .orElseThrow(() -> new FailedInspectionException(repoPath, String.format("Failed to find component version for component '%s'.", externalIdString)));
 
         try {
-            projectBomService.addComponentToProjectVersion(componentVersionView.get(), projectVersionView);
+            projectBomService.addComponentToProjectVersion(componentVersionView, projectVersionView);
         } catch (IntegrationRestException e) {
             handleIntegrationRestException(repoPath, e);
         } catch (BlackDuckApiException e) {
             handleIntegrationRestException(repoPath, e.getOriginalIntegrationRestException());
         }
-        componentViewWrapper = getComponentViewWrapper(componentVersionView.get(), projectVersionView);
+        componentViewWrapper = getComponentViewWrapper(componentVersionView, projectVersionView);
 
         return componentViewWrapper;
     }

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractorTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractorTest.java
@@ -28,6 +28,10 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.externa
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.SupportedPackageType;
 
 class ComposerExternalIdExtractorTest {
+    private static final String PACKAGE_NAME = "console";
+    private static final String PACKAGE_VERSION = "1.2.3";
+    private static final String PACKAGE_HASH = "12345";
+    private static final String PACKAGE_EXTENSION = "zip";
 
     @Test
     void extractExternalId() {
@@ -36,26 +40,26 @@ class ComposerExternalIdExtractorTest {
         ComposerExternalIdExtractor composerExternalIdExtractor = new ComposerExternalIdExtractor(composerVersionSelector, composerJsonService);
 
         PluginRepoPathFactory repoPathFactory = new PluginRepoPathFactory(false);
-        RepoPath repoPath = repoPathFactory.create("test-repo", "console-12345.zip");
+        RepoPath repoPath = repoPathFactory.create("test-repo", String.format("%s-%s.%s", PACKAGE_NAME, PACKAGE_HASH, PACKAGE_EXTENSION));
 
         Mockito.when(composerJsonService.findJsonFiles(repoPath)).thenReturn(
             new ComposerJsonResult(
-                new FileNamePieces("console", "12345", "zip"),
+                new FileNamePieces(PACKAGE_NAME, PACKAGE_HASH, PACKAGE_EXTENSION),
                 Collections.singletonList(repoPath)
             )
         );
 
         ComposerVersion composerVersion = new ComposerVersion();
-        composerVersion.name = "console";
-        composerVersion.version = "1.2.3";
+        composerVersion.name = PACKAGE_NAME;
+        composerVersion.version = PACKAGE_VERSION;
         VersionSource versionSource = new VersionSource();
-        versionSource.reference = "12345";
+        versionSource.reference = PACKAGE_HASH;
         composerVersion.versionSource = versionSource;
         Mockito.when(composerJsonService.parseJson(repoPath)).thenReturn(
             Collections.singletonList(composerVersion)
         );
 
-        ExternalId externalId = new ExternalIdFactory().createNameVersionExternalId(Forge.PACKAGIST, "console", "1.2.3");
+        ExternalId externalId = new ExternalIdFactory().createNameVersionExternalId(Forge.PACKAGIST, PACKAGE_NAME, PACKAGE_VERSION);
         Mockito.when(composerVersionSelector.discoverMatchingVersion(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(
             Optional.of(externalId)
         );

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractorTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractorTest.java
@@ -1,0 +1,61 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Collections;
+import java.util.Optional;
+
+import org.artifactory.repo.RepoPath;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.bdio.model.Forge;
+import com.synopsys.integration.bdio.model.externalid.ExternalId;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.blackduck.artifactory.PluginRepoPathFactory;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerJsonResult;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerVersion;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.FileNamePieces;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.VersionSource;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.SupportedPackageType;
+
+class ComposerExternalIdExtractorTest {
+
+    @Test
+    void extractExternalId() {
+        ComposerVersionSelector composerVersionSelector = Mockito.mock(ComposerVersionSelector.class);
+        ComposerJsonService composerJsonService = Mockito.mock(ComposerJsonService.class);
+        ComposerExternalIdExtractor composerExternalIdExtractor = new ComposerExternalIdExtractor(composerVersionSelector, composerJsonService);
+
+        PluginRepoPathFactory repoPathFactory = new PluginRepoPathFactory(false);
+        RepoPath repoPath = repoPathFactory.create("test-repo", "console-12345.zip");
+
+        Mockito.when(composerJsonService.findJsonFiles(repoPath)).thenReturn(
+            new ComposerJsonResult(
+                new FileNamePieces("console", "12345", "zip"),
+                Collections.singletonList(repoPath)
+            )
+        );
+
+        ComposerVersion composerVersion = new ComposerVersion();
+        composerVersion.name = "console";
+        composerVersion.version = "1.2.3";
+        VersionSource versionSource = new VersionSource();
+        versionSource.reference = "12345";
+        composerVersion.versionSource = versionSource;
+        Mockito.when(composerJsonService.parseJson(repoPath)).thenReturn(
+            Collections.singletonList(composerVersion)
+        );
+
+        ExternalId externalId = new ExternalIdFactory().createNameVersionExternalId(Forge.PACKAGIST, "console", "1.2.3");
+        Mockito.when(composerVersionSelector.discoverMatchingVersion(Mockito.any(), Mockito.any(), Mockito.any())).thenReturn(
+            Optional.of(externalId)
+        );
+
+        Optional<ExternalId> actualExternalId = composerExternalIdExtractor.extractExternalId(SupportedPackageType.COMPOSER, repoPath);
+
+        assertTrue(actualExternalId.isPresent());
+        assertEquals(externalId.createExternalId(), actualExternalId.get().createExternalId());
+    }
+}

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractorTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerExternalIdExtractorTest.java
@@ -1,3 +1,10 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonServiceTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonServiceTest.java
@@ -1,0 +1,85 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.List;
+
+import org.artifactory.repo.RepoPath;
+import org.artifactory.resource.ResourceStreamHandle;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.PluginRepoPathFactory;
+import com.synopsys.integration.blackduck.artifactory.TestUtil;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerJsonResult;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerVersion;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.FileNamePieces;
+
+import lombok.SneakyThrows;
+
+class ComposerJsonServiceTest {
+
+    @Test
+    void findJsonFiles() {
+        PluginRepoPathFactory repoPathFactory = new PluginRepoPathFactory(false);
+        RepoPath repoPath = repoPathFactory.create("test-repo", "console-1ba4560dbbb9fcf5ae28b61f71f49c678086cf23.zip");
+        RepoPath jsonRepoPath = repoPathFactory.create("test-repo", ".composer/p/symfony/console.json");
+        List<RepoPath> jsonRepoPaths = Collections.singletonList(jsonRepoPath);
+
+        ArtifactoryPAPIService artifactoryPAPIService = Mockito.mock(ArtifactoryPAPIService.class);
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        ComposerJsonService composerJsonService = new ComposerJsonService(artifactoryPAPIService, gson);
+
+        Mockito.when(artifactoryPAPIService.itemsByName("console.json", "test-repo"))
+            .thenReturn(jsonRepoPaths);
+
+        ComposerJsonResult composerJsonResult = composerJsonService.findJsonFiles(repoPath);
+
+        FileNamePieces fileNamePieces = composerJsonResult.getFileNamePieces();
+        assertEquals("console", fileNamePieces.getComponentName());
+        assertEquals("1ba4560dbbb9fcf5ae28b61f71f49c678086cf23", fileNamePieces.getHash());
+        assertEquals("zip", fileNamePieces.getExtension());
+        assertEquals(jsonRepoPaths, composerJsonResult.getRepoPaths());
+    }
+
+    @Test
+    void parseJson() {
+        PluginRepoPathFactory repoPathFactory = new PluginRepoPathFactory(false);
+        RepoPath jsonRepoPath = repoPathFactory.create("test-repo", ".composer/p/symfony/console.json");
+
+        ArtifactoryPAPIService artifactoryPAPIService = Mockito.mock(ArtifactoryPAPIService.class);
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        ComposerJsonService composerJsonService = new ComposerJsonService(artifactoryPAPIService, gson);
+
+        Mockito.when(artifactoryPAPIService.getArtifactContent(jsonRepoPath))
+            .thenReturn(new ResourceStreamHandle() {
+                final InputStream inputStream = TestUtil.INSTANCE.getResourceAsStream("/console.json");
+
+                @Override
+                public InputStream getInputStream() {
+                    return inputStream;
+                }
+
+                @SneakyThrows
+                @Override
+                public long getSize() {
+                    return inputStream.available();
+                }
+
+                @SneakyThrows
+                @Override
+                public void close() {
+                    inputStream.close();
+                }
+            });
+
+        List<ComposerVersion> composerVersions = composerJsonService.parseJson(jsonRepoPath);
+
+        assertEquals(3, composerVersions.size());
+    }
+}

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonServiceTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerJsonServiceTest.java
@@ -1,3 +1,10 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
@@ -1,0 +1,53 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.bdio.model.externalid.ExternalId;
+import com.synopsys.integration.bdio.model.externalid.ExternalIdFactory;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.ComposerVersion;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer.model.VersionSource;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.SupportedPackageType;
+
+class ComposerVersionSelectorTest {
+
+    @Test
+    void discoverMatchingVersion() {
+        ExternalIdFactory externalIdFactory = new ExternalIdFactory();
+        ComposerVersionSelector composerVersionSelector = new ComposerVersionSelector(externalIdFactory);
+
+        SupportedPackageType supportedPackageType = SupportedPackageType.COMPOSER;
+        String artifactHash = "12345";
+        VersionSource commonVersionSource = new VersionSource();
+        commonVersionSource.reference = artifactHash;
+
+        List<ComposerVersion> composerVersions = new ArrayList<>();
+
+        ComposerVersion devVersion = new ComposerVersion();
+        devVersion.name = "dont-pick-me";
+        devVersion.version = "some-dev-version-1.X";
+        devVersion.versionSource = commonVersionSource;
+        composerVersions.add(devVersion);
+
+        ComposerVersion devVersion2 = new ComposerVersion();
+        devVersion2.name = "dont-pick-me-2";
+        devVersion2.version = "some-dev-version-2.X";
+        devVersion2.versionSource = commonVersionSource;
+        composerVersions.add(devVersion2);
+
+        ComposerVersion actualVersion = new ComposerVersion();
+        actualVersion.name = "pick-me";
+        actualVersion.version = "1.0.0";
+        actualVersion.versionSource = commonVersionSource;
+        composerVersions.add(actualVersion);
+
+        Optional<ExternalId> externalId = composerVersionSelector.discoverMatchingVersion(supportedPackageType, artifactHash, composerVersions);
+
+        Assertions.assertTrue(externalId.isPresent());
+        Assertions.assertEquals("pick-me:1.0.0", externalId.get().createExternalId());
+    }
+}

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
@@ -1,10 +1,12 @@
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.synopsys.integration.bdio.model.externalid.ExternalId;
@@ -47,7 +49,7 @@ class ComposerVersionSelectorTest {
 
         Optional<ExternalId> externalId = composerVersionSelector.discoverMatchingVersion(supportedPackageType, artifactHash, composerVersions);
 
-        Assertions.assertTrue(externalId.isPresent());
-        Assertions.assertEquals("pick-me:1.0.0", externalId.get().createExternalId());
+        assertTrue(externalId.isPresent());
+        assertEquals("pick-me:1.0.0", externalId.get().createExternalId());
     }
 }

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
@@ -1,3 +1,10 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.externalid.composer;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/externalid/composer/ComposerVersionSelectorTest.java
@@ -48,15 +48,17 @@ class ComposerVersionSelectorTest {
         devVersion2.versionSource = commonVersionSource;
         composerVersions.add(devVersion2);
 
-        ComposerVersion actualVersion = new ComposerVersion();
-        actualVersion.name = "pick-me";
-        actualVersion.version = "1.0.0";
-        actualVersion.versionSource = commonVersionSource;
-        composerVersions.add(actualVersion);
+        String expectedName = "pick-me";
+        String expectedVersion = "1.0.0";
+        ComposerVersion expectedComposerVersion = new ComposerVersion();
+        expectedComposerVersion.name = "pick-me";
+        expectedComposerVersion.version = expectedVersion;
+        expectedComposerVersion.versionSource = commonVersionSource;
+        composerVersions.add(expectedComposerVersion);
 
         Optional<ExternalId> externalId = composerVersionSelector.discoverMatchingVersion(supportedPackageType, artifactHash, composerVersions);
 
         assertTrue(externalId.isPresent());
-        assertEquals("pick-me:1.0.0", externalId.get().createExternalId());
+        assertEquals(String.format("%s:%s", expectedName, expectedVersion), externalId.get().createExternalId());
     }
 }

--- a/blackduck-artifactory-common/src/test/resources/console.json
+++ b/blackduck-artifactory-common/src/test/resources/console.json
@@ -1,0 +1,27 @@
+{
+  "packages": {
+    "symfony/console": {
+      "20.0.0": {
+        "name": "symfony/console",
+        "version": "20.0.0",
+        "source": {
+          "reference": "1ba4560dbbb9fcf5ae28b61f71f49c678086cf23"
+        }
+      },
+      "40.0.0-dev": {
+        "name": "symfony/console",
+        "version": "40.0.0-dev",
+        "source": {
+          "reference": "1ba4560dbbb9fcf5ae28b61f71f49c678086cf23"
+        }
+      },
+      "40.0.0": {
+        "name": "symfony/console",
+        "version": "40.0.0",
+        "source": {
+          "reference": "1ba4560dbbb9fcf5ae28b61f71f49c678086cf23"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Fixes IARTH-438.
Some KB mismatches were due to the plugin using dev versions with the same hash.

ComposerExternalIdExtractor was doing too much, so I broke that up into `ComposerVersionSelector` and `ComposerJsonService`.
I also added test coverage to the `...inspection.externalid.composer` package.