### PR TITLE
Blocked downloads fix

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDecider.java
@@ -35,12 +35,12 @@ public class ScanCancelDecider implements CancelDecider {
     @Override
     public CancelDecision getCancelDecision(RepoPath repoPath) {
         boolean metadataBlockDisabled = FALSE.equals(scanModuleConfig.isMetadataBlockEnabled());
-        boolean shouldNotScanRepository = !scanModuleConfig.getRepos().contains(repoPath.getRepoKey()); // TODO: This should be a call to another service
+        boolean shouldNotScanRepository = !scanModuleConfig.getRepos().contains(repoPath.getRepoKey()); // TODO: This should be a call to another service - JM 04/2021
         if (metadataBlockDisabled || shouldNotScanRepository) {
             return CancelDecision.NO_CANCELLATION();
         }
 
-        // Getting ItemInfo from a virtual repository causes an exception resulting in failed downloads. We must verify the repository before doing this check. (IARTH-434)
+        // Getting ItemInfo from a virtual repository causes an exception resulting in failed downloads. We must verify the repository before doing this check. IARTH-434 - JM 04/2021
         ItemInfo itemInfo = artifactoryPAPIService.getItemInfo(repoPath);
         if (itemInfo.isFolder()) {
             return CancelDecision.NO_CANCELLATION();

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDecider.java
@@ -46,18 +46,17 @@ public class ScanCancelDecider implements CancelDecider {
             return CancelDecision.NO_CANCELLATION();
         }
 
-        Optional<Result> scanResult = scanPropertyService.getScanResult(repoPath);
-        if (scanResult.isPresent() && Result.FAILURE.equals(scanResult.get())) {
-            return CancelDecision.CANCEL_DOWNLOAD(String.format("The artifact was not successfully scanned. Found result %s.", Result.FAILURE));
-        } else if (scanResult.isPresent() && Result.SUCCESS.equals(scanResult.get())) {
-            return CancelDecision.NO_CANCELLATION();
-        }
-
         File artifact = new File(itemInfo.getName());
-
         for (String namePattern : scanModuleConfig.getNamePatterns()) {
             WildcardFileFilter wildcardFileFilter = new WildcardFileFilter(namePattern);
             if (wildcardFileFilter.accept(artifact)) {
+                Optional<Result> scanResult = scanPropertyService.getScanResult(repoPath);
+                if (scanResult.isPresent() && Result.FAILURE.equals(scanResult.get())) {
+                    return CancelDecision.CANCEL_DOWNLOAD(String.format("The artifact was not successfully scanned. Found result %s.", Result.FAILURE));
+                } else if (scanResult.isPresent() && Result.SUCCESS.equals(scanResult.get())) {
+                    return CancelDecision.NO_CANCELLATION();
+                }
+                // Only continues if no scan result is found.
                 return CancelDecision.CANCEL_DOWNLOAD(String.format("Missing the %s scan result on an artifact that should be scanned.", Result.SUCCESS));
             }
         }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDecider.java
@@ -35,9 +35,14 @@ public class ScanCancelDecider implements CancelDecider {
     @Override
     public CancelDecision getCancelDecision(RepoPath repoPath) {
         boolean metadataBlockDisabled = FALSE.equals(scanModuleConfig.isMetadataBlockEnabled());
-        boolean shouldScanRepository = !scanModuleConfig.getRepos().contains(repoPath.getRepoKey());
+        boolean shouldNotScanRepository = !scanModuleConfig.getRepos().contains(repoPath.getRepoKey()); // TODO: This should be a call to another service
+        if (metadataBlockDisabled || shouldNotScanRepository) {
+            return CancelDecision.NO_CANCELLATION();
+        }
+
+        // Getting ItemInfo from a virtual repository causes an exception resulting in failed downloads. We must verify the repository before doing this check. (IARTH-434)
         ItemInfo itemInfo = artifactoryPAPIService.getItemInfo(repoPath);
-        if (metadataBlockDisabled || shouldScanRepository || itemInfo.isFolder()) {
+        if (itemInfo.isFolder()) {
             return CancelDecision.NO_CANCELLATION();
         }
 

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDeciderTest.java
@@ -1,0 +1,81 @@
+package com.synopsys.integration.blackduck.artifactory.modules.cancel;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import org.artifactory.fs.ItemInfo;
+import org.artifactory.repo.RepoPath;
+import org.jetbrains.annotations.Nullable;
+import org.junit.jupiter.api.Test;
+import org.junit.platform.commons.util.StringUtils;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.PluginRepoPathFactory;
+import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanModuleConfig;
+import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanPropertyService;
+import com.synopsys.integration.blackduck.codelocation.Result;
+
+class ScanCancelDeciderTest {
+    @Test
+    void getCancelDecision() {
+        List<Result> scanResults = new ArrayList<>(Arrays.asList(Result.values()));
+        scanResults.add(null);
+
+        for (Result scanResult : scanResults) {
+            testDecision(false, false, false, scanResult);
+            testDecision(false, false, true, scanResult);
+            testDecision(false, true, false, scanResult);
+            testDecision(false, true, true, scanResult);
+            testDecision(true, false, false, scanResult); // TODO: Don't block
+            testDecision(true, false, true, scanResult);
+            testDecision(true, true, false, scanResult);
+            testDecision(true, true, true, scanResult);
+        }
+    }
+
+    private void testDecision(boolean metadataBlockEnabled, boolean isFolder, boolean matchesExtension, @Nullable Result scanResult) {
+        CancelDecision cancelDecision = getDecision(metadataBlockEnabled, isFolder, matchesExtension, scanResult);
+        if (!metadataBlockEnabled || isFolder || !matchesExtension) {
+            assertFalse(cancelDecision.shouldCancelDownload());
+            assertTrue(StringUtils.isBlank(cancelDecision.getCancelReason()));
+        } else if (scanResult == null || Result.FAILURE.equals(scanResult)) {
+            assertTrue(cancelDecision.shouldCancelDownload(), "Scan result missing or FAILURE. Should cancel.");
+            assertTrue(StringUtils.isNotBlank(cancelDecision.getCancelReason()));
+        } else {
+            assertFalse(cancelDecision.shouldCancelDownload(), "Scan Result: " + scanResult.name());
+            assertTrue(StringUtils.isBlank(cancelDecision.getCancelReason()));
+        }
+    }
+
+    private CancelDecision getDecision(boolean metadataBlockEnabled, boolean isFolder, boolean matchesExtension, @Nullable Result scanResult) {
+        ScanModuleConfig scanModuleConfig = Mockito.mock(ScanModuleConfig.class);
+        ScanPropertyService scanPropertyService = Mockito.mock(ScanPropertyService.class);
+        ArtifactoryPAPIService artifactoryPAPIService = Mockito.mock(ArtifactoryPAPIService.class);
+        ScanCancelDecider scanCancelDecider = new ScanCancelDecider(scanModuleConfig, scanPropertyService, artifactoryPAPIService);
+
+        PluginRepoPathFactory pluginRepoPathFactory = new PluginRepoPathFactory(false);
+        RepoPath testRepoPath = pluginRepoPathFactory.create("test-repo");
+        RepoPath artifactRepoPath = pluginRepoPathFactory.create(testRepoPath.getRepoKey(), "artifact-to-be-scanned.zip");
+        ItemInfo artifactItemInfo = Mockito.mock(ItemInfo.class);
+
+        Mockito.when(scanModuleConfig.isMetadataBlockEnabled()).thenReturn(metadataBlockEnabled);
+        Mockito.when(scanModuleConfig.getRepos()).thenReturn(Collections.singletonList(testRepoPath.getRepoKey()));
+        Mockito.when(artifactItemInfo.isFolder()).thenReturn(isFolder);
+        Mockito.when(artifactoryPAPIService.getItemInfo(artifactRepoPath)).thenReturn(artifactItemInfo);
+
+        Mockito.when(scanPropertyService.getScanResult(artifactRepoPath)).thenReturn(Optional.ofNullable(scanResult));
+
+        Mockito.when(artifactItemInfo.getName()).thenReturn("artifact-to-be-scanned.zip");
+        String artifactExtension = matchesExtension ? ".zip" : ".doesntmatch";
+        Mockito.when(scanModuleConfig.getNamePatterns()).thenReturn(Collections.singletonList("*" + artifactExtension));
+
+        return scanCancelDecider.getCancelDecision(artifactRepoPath);
+    }
+}

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanCancelDeciderTest.java
@@ -33,7 +33,7 @@ class ScanCancelDeciderTest {
             testDecision(false, false, true, scanResult);
             testDecision(false, true, false, scanResult);
             testDecision(false, true, true, scanResult);
-            testDecision(true, false, false, scanResult); // TODO: Don't block
+            testDecision(true, false, false, scanResult);
             testDecision(true, false, true, scanResult);
             testDecision(true, true, false, scanResult);
             testDecision(true, true, true, scanResult);


### PR DESCRIPTION
Fixes IARTH-434.

The plugin was checking for `ItemInfo` at the same time it was verifying the repository is configured to be scanned.
The problem with this is that if the download is coming via a virtual repository, we would still call the Artifactory API to get `ItemInfo` which would throw an exception because virtual repositories don't have `ItemInfo`. 
The download would be canceled due to the thrown runtime exception. 

`CancelDecision cancelDecision = getCancelDecision(repoPath);`
I considered also wrapping line 18 from `CancelDecider` with a try-catch and allow downloads when we throw an exception. That could lead to downloads of vulnerable components since the plugin would just be logging stuff and would likely go unnoticed. 

The workaround for us throwing an exception in the future would be to disable metadata blocking (`blackduck.artifactory.scan.metadata.block=false`) until a fix it released.

This PR also fixes and issue where we would block downloads of artifacts that had BlackDuck properties warranting a block, but are no longer configured to be scanned by the plugin via the `blackduck.artifactory.scan.name.patterns` property. 