### PR TITLE
feat(inspection): Removed upgrade executions. (Completes IARTH-440)

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
@@ -59,10 +59,6 @@ public class PluginAPI implements Analyzable {
         LogUtil.finish(logger, functionName, triggerType);
     }
 
-    public void performPluginUpgrades(TriggerType triggerType) {
-        runMethod(inspectionModule, triggerType, inspectionModule::performUpgrades);
-    }
-
     public void triggerScan(TriggerType triggerType) {
         runMethod(scanModule, triggerType, scanModule::triggerScan);
     }

--- a/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
+++ b/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
@@ -190,9 +190,7 @@ executions {
     blackDuckReloadScannerDirectory() { params -> pluginAPI.reloadBlackDuckScannerDirectory(TriggerType.REST_REQUEST) }
 
     //////////////////////////////////////////////// INSPECTOR EXECUTIONS ////////////////////////////////////////////////
-
-    blackDuckPerformInspectionUpgrades(httpMethod: 'POST') { params -> pluginAPI.performPluginUpgrades(TriggerType.REST_REQUEST) }
-
+    
     /**
      * Manual execution of the Repository Initialization step of inspection.
      * Automatic execution is performed by the blackDuckInitializeRepos CRON job below.


### PR DESCRIPTION
In the development of 7.X of the plugin, we added additional features that required additional or modified properties on artifacts.

These upgrade executions were a automatically executed on the user's behalf until 7.3.0 where the customer would have to hit the "blackDuckPerformInspectionUpgrades" endpoint. 
Given this is a major release, the deprecated properties and upgrade executions will be removed.

Customer's upgrading to 8.0.0 should clear all their inspected properties via the "blackDuckDeleteInspectionProperties" before uninstalling the plugin. QA might be able to confirm whether it is okay to install the new plugin, then run that endpoint, as opposed to running it before removing the old plugin.