### PR TITLE
Component version id

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/ArtifactSearchService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/ArtifactSearchService.java
@@ -14,7 +14,6 @@ import org.artifactory.repo.RepoPath;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.SetMultimap;
-import com.synopsys.integration.blackduck.artifactory.modules.inspection.service.InspectionPropertyService;
 
 // TODO: Move search services from ArtifactoryPropertyService to here.
 public class ArtifactSearchService {
@@ -26,14 +25,14 @@ public class ArtifactSearchService {
         this.artifactoryPropertyService = artifactoryPropertyService;
     }
 
-    public List<RepoPath> findArtifactsUsingComponentNameVersions(String componentName, String componentVersionName, List<RepoPath> repoKeyPaths) {
+    public List<RepoPath> findArtifactsWithComponentVersionId(String componentVersionId, List<RepoPath> repoKeyPaths) {
         List<String> repoKeys = repoKeyPaths.stream().map(RepoPath::getRepoKey).collect(Collectors.toList());
-        return findArtifactsWithComponentNameVersion(componentName, componentVersionName, repoKeys);
+        return findArtifactsWithComponentVersionIdFromKeys(componentVersionId, repoKeys);
     }
 
-    public List<RepoPath> findArtifactsWithComponentNameVersion(String componentName, String componentVersionName, List<String> repoKeys) {
+    public List<RepoPath> findArtifactsWithComponentVersionIdFromKeys(String componentVersionId, List<String> repoKeys) {
         SetMultimap<String, String> setMultimap = HashMultimap.create();
-        setMultimap.put(BlackDuckArtifactoryProperty.COMPONENT_NAME_VERSION.getPropertyName(), String.format(InspectionPropertyService.COMPONENT_NAME_VERSION_FORMAT, componentName, componentVersionName));
+        setMultimap.put(BlackDuckArtifactoryProperty.COMPONENT_VERSION_ID.getPropertyName(), componentVersionId);
 
         return artifactoryPropertyService.getItemsContainingPropertiesAndValues(setMultimap, repoKeys.toArray(new String[0]));
     }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
@@ -21,7 +21,9 @@ public enum BlackDuckArtifactoryProperty {
     POLICY_STATUS("policyStatus"),
     POLICY_SEVERITY_TYPES("policySeverityTypes"),
     COMPONENT_VERSION_URL("componentVersionUrl"),
+    @Deprecated
     COMPONENT_NAME_VERSION("componentNameVersion"),
+    COMPONENT_VERSION_ID("componentVersionId"),
     PROJECT_VERSION_UI_URL("uiUrl"),
     OVERALL_POLICY_STATUS("overallPolicyStatus"),
     LAST_INSPECTION("lastInspection"),

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ArtifactNotificationService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ArtifactNotificationService.java
@@ -103,12 +103,11 @@ public class ArtifactNotificationService {
     private List<PolicyAffectedArtifact> findPolicyAffectedArtifacts(List<ProcessedPolicyNotification> processedPolicyNotifications) {
         List<PolicyAffectedArtifact> affectedArtifacts = new ArrayList<>();
         for (ProcessedPolicyNotification processedPolicyNotification : processedPolicyNotifications) {
-            String componentName = processedPolicyNotification.getComponentName();
-            String componentVersionName = processedPolicyNotification.getComponentVersionName();
+            String componentVersionId = processedPolicyNotification.getComponentVersionId();
             PolicyStatusReport policyStatusReport = processedPolicyNotification.getPolicyStatusReport();
             List<RepoPath> affectedProjects = processedPolicyNotification.getAffectedRepoKeyPaths();
 
-            List<RepoPath> foundArtifacts = artifactSearchService.findArtifactsUsingComponentNameVersions(componentName, componentVersionName, affectedProjects);
+            List<RepoPath> foundArtifacts = artifactSearchService.findArtifactsWithComponentVersionId(componentVersionId, affectedProjects);
             affectedArtifacts.add(new PolicyAffectedArtifact(foundArtifacts, policyStatusReport));
         }
 
@@ -118,11 +117,10 @@ public class ArtifactNotificationService {
     private List<VulnerabilityAffectedArtifact> findVulnerabilityAffectedArtifacts(List<ProcessedVulnerabilityNotification> processedVulnerabilityNotifications) {
         List<VulnerabilityAffectedArtifact> affectedArtifacts = new ArrayList<>();
         for (ProcessedVulnerabilityNotification processedVulnerabilityNotification : processedVulnerabilityNotifications) {
-            String componentName = processedVulnerabilityNotification.getComponentName();
-            String componentVersionName = processedVulnerabilityNotification.getComponentVersionName();
+            String componentVersionId = processedVulnerabilityNotification.getComponentVersionId();
             List<RepoPath> affectedProjects = processedVulnerabilityNotification.getAffectedRepoKeyPaths();
 
-            List<RepoPath> foundArtifacts = artifactSearchService.findArtifactsUsingComponentNameVersions(componentName, componentVersionName, affectedProjects);
+            List<RepoPath> foundArtifacts = artifactSearchService.findArtifactsWithComponentVersionId(componentVersionId, affectedProjects);
             affectedArtifacts.add(new VulnerabilityAffectedArtifact(foundArtifacts, processedVulnerabilityNotification.getVulnerabilityAggregate()));
         }
 

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtil.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtil.java
@@ -1,0 +1,29 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2021 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.synopsys.integration.blackduck.api.generated.discovery.BlackDuckMediaTypeDiscovery;
+import com.synopsys.integration.exception.IntegrationException;
+
+public class ComponentVersionIdUtil {
+    private static final Pattern COMPONENT_VERSION_ID_PATTERN = Pattern.compile(String.format(".*/components/%s/versions/(%s).*", BlackDuckMediaTypeDiscovery.UUID_REGEX, BlackDuckMediaTypeDiscovery.UUID_REGEX));
+
+    private ComponentVersionIdUtil() {}
+
+    public static String extractComponentVersionId(String componentVersionUrl) throws IntegrationException {
+        Matcher matcher = COMPONENT_VERSION_ID_PATTERN.matcher(componentVersionUrl);
+        if (matcher.matches()) {
+            return matcher.group(1);
+        } else {
+            throw new IntegrationException(String.format("Component Version URL does not match pattern %s", COMPONENT_VERSION_ID_PATTERN.pattern()));
+        }
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/ComponentVersionIdUtil.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/ComponentVersionIdUtil.java
@@ -5,7 +5,7 @@
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications;
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme;
 
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/ComponentVersionIdUtil.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/ComponentVersionIdUtil.java
@@ -7,23 +7,20 @@
  */
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme;
 
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.Arrays;
 
-import com.synopsys.integration.blackduck.api.generated.discovery.BlackDuckMediaTypeDiscovery;
 import com.synopsys.integration.exception.IntegrationException;
+import com.synopsys.integration.rest.HttpUrl;
 
+// TODO: blackduck-common:55.0.0 will support parsing UUIDs from BlackDuckUrls and should be used in the next release of blackduck-artifactory. - JM 05/2021
 public class ComponentVersionIdUtil {
-    private static final Pattern COMPONENT_VERSION_ID_PATTERN = Pattern.compile(String.format(".*/components/%s/versions/(%s).*", BlackDuckMediaTypeDiscovery.UUID_REGEX, BlackDuckMediaTypeDiscovery.UUID_REGEX));
 
     private ComponentVersionIdUtil() {}
 
     public static String extractComponentVersionId(String componentVersionUrl) throws IntegrationException {
-        Matcher matcher = COMPONENT_VERSION_ID_PATTERN.matcher(componentVersionUrl);
-        if (matcher.matches()) {
-            return matcher.group(1);
-        } else {
-            throw new IntegrationException(String.format("Component Version URL does not match pattern %s", COMPONENT_VERSION_ID_PATTERN.pattern()));
-        }
+        TempBlackDuckUrl tempBlackDuckUrl = new TempBlackDuckUrl(new HttpUrl(componentVersionUrl));
+        return tempBlackDuckUrl.parseId(Arrays.asList(TempBlackDuckUrlSearchTerm.COMPONENTS, TempBlackDuckUrlSearchTerm.VERSIONS));
     }
+
 }
+

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/TempBlackDuckUrl.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/TempBlackDuckUrl.java
@@ -1,0 +1,28 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme;
+
+import java.util.List;
+
+import com.synopsys.integration.rest.HttpUrl;
+
+public class TempBlackDuckUrl {
+    private final HttpUrl url;
+
+    public TempBlackDuckUrl(HttpUrl url) {
+        this.url = url;
+    }
+
+    // TODO: This is the copied from the blackduck-common:55.0.0 implementation prior to its release and should be removed when possible. - JM 05/2021
+    public String parseId(List<TempBlackDuckUrlSearchTerm> searchTerms) {
+        String searching = url.string();
+        int afterLastTermIndex = -1;
+        for (TempBlackDuckUrlSearchTerm searchTerm : searchTerms) {
+            afterLastTermIndex = searching.indexOf(searchTerm.getTerm(), afterLastTermIndex) + 1;
+        }
+        int afterFirstSlashIndex = searching.indexOf('/', afterLastTermIndex) + 1;
+        int secondSlashIndex = searching.indexOf('/', afterFirstSlashIndex);
+        int end = secondSlashIndex > afterFirstSlashIndex ? secondSlashIndex : searching.length();
+        searching = searching.substring(afterFirstSlashIndex, end);
+        return searching;
+    }
+
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/TempBlackDuckUrlSearchTerm.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/TempBlackDuckUrlSearchTerm.java
@@ -1,5 +1,6 @@
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme;
 
+// TODO: This is the copied from the blackduck-common:55.0.0 implementation prior to its release and should be removed when possible. - JM 05/2021
 public class TempBlackDuckUrlSearchTerm {
     public static final TempBlackDuckUrlSearchTerm PROJECTS = new TempBlackDuckUrlSearchTerm("projects");
     public static final TempBlackDuckUrlSearchTerm VERSIONS = new TempBlackDuckUrlSearchTerm("versions");

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/TempBlackDuckUrlSearchTerm.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/deleteme/TempBlackDuckUrlSearchTerm.java
@@ -1,0 +1,19 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme;
+
+public class TempBlackDuckUrlSearchTerm {
+    public static final TempBlackDuckUrlSearchTerm PROJECTS = new TempBlackDuckUrlSearchTerm("projects");
+    public static final TempBlackDuckUrlSearchTerm VERSIONS = new TempBlackDuckUrlSearchTerm("versions");
+    public static final TempBlackDuckUrlSearchTerm COMPONENTS = new TempBlackDuckUrlSearchTerm("components");
+    public static final TempBlackDuckUrlSearchTerm ORIGINS = new TempBlackDuckUrlSearchTerm("origins");
+
+    private final String term;
+
+    public TempBlackDuckUrlSearchTerm(String term) {
+        this.term = term;
+    }
+
+    public String getTerm() {
+        return term;
+    }
+
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyOverrideProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyOverrideProcessor.java
@@ -19,6 +19,7 @@ import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersi
 import com.synopsys.integration.blackduck.api.manual.component.PolicyOverrideNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.PolicyOverrideNotificationUserView;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.PolicyNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
 import com.synopsys.integration.exception.IntegrationException;
@@ -49,7 +50,10 @@ public class PolicyOverrideProcessor {
             ProjectVersionComponentPolicyStatusType policySummaryStatusType = policyNotificationService.fetchApprovalStatus(content.getBomComponentVersionPolicyStatus());
             PolicyStatusReport policyStatusReport = new PolicyStatusReport(policySummaryStatusType, policySeverityTypes);
 
-            processedPolicyNotification = new ProcessedPolicyNotification(content.getComponentName(), content.getComponentVersionName(), policyStatusReport, Collections.singletonList(repoKeyPath.get()));
+            String componentVersionUrl = content.getComponentVersion();
+            String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId(componentVersionUrl);
+
+            processedPolicyNotification = new ProcessedPolicyNotification(content.getComponentName(), content.getComponentVersionName(), componentVersionId, policyStatusReport, Collections.singletonList(repoKeyPath.get()));
         }
 
         return Optional.ofNullable(processedPolicyNotification);

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyOverrideProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyOverrideProcessor.java
@@ -19,9 +19,9 @@ import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersi
 import com.synopsys.integration.blackduck.api.manual.component.PolicyOverrideNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.PolicyOverrideNotificationUserView;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
-import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.PolicyNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme.ComponentVersionIdUtil;
 import com.synopsys.integration.exception.IntegrationException;
 
 public class PolicyOverrideProcessor {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyRuleClearedProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyRuleClearedProcessor.java
@@ -20,9 +20,9 @@ import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionS
 import com.synopsys.integration.blackduck.api.manual.component.RuleViolationClearedNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.RuleViolationClearedNotificationUserView;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
-import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.PolicyNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme.ComponentVersionIdUtil;
 import com.synopsys.integration.exception.IntegrationException;
 
 public class PolicyRuleClearedProcessor {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyRuleClearedProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyRuleClearedProcessor.java
@@ -20,6 +20,7 @@ import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionS
 import com.synopsys.integration.blackduck.api.manual.component.RuleViolationClearedNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.RuleViolationClearedNotificationUserView;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.PolicyNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
 import com.synopsys.integration.exception.IntegrationException;
@@ -55,7 +56,9 @@ public class PolicyRuleClearedProcessor {
 
                 String componentName = componentVersionStatus.getComponentName();
                 String componentVersionName = componentVersionStatus.getComponentVersionName();
-                ProcessedPolicyNotification processedNotification = new ProcessedPolicyNotification(componentName, componentVersionName, policyStatusReport, Collections.singletonList(repoKeyPath.get()));
+                String componentVersionUrl = componentVersionStatus.getComponentVersion();
+                String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId(componentVersionUrl);
+                ProcessedPolicyNotification processedNotification = new ProcessedPolicyNotification(componentName, componentVersionName, componentVersionId, policyStatusReport, Collections.singletonList(repoKeyPath.get()));
                 processedPolicyNotifications.add(processedNotification);
             }
         }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyViolationProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyViolationProcessor.java
@@ -20,9 +20,9 @@ import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionS
 import com.synopsys.integration.blackduck.api.manual.component.RuleViolationNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.RuleViolationNotificationUserView;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
-import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.PolicyNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme.ComponentVersionIdUtil;
 import com.synopsys.integration.exception.IntegrationException;
 
 public class PolicyViolationProcessor {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyViolationProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/PolicyViolationProcessor.java
@@ -20,6 +20,7 @@ import com.synopsys.integration.blackduck.api.manual.component.ComponentVersionS
 import com.synopsys.integration.blackduck.api.manual.component.RuleViolationNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.RuleViolationNotificationUserView;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.PolicyNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
 import com.synopsys.integration.exception.IntegrationException;
@@ -52,7 +53,10 @@ public class PolicyViolationProcessor {
 
                 String componentName = componentVersionStatus.getComponentName();
                 String componentVersionName = componentVersionStatus.getComponentVersionName();
-                ProcessedPolicyNotification processedNotification = new ProcessedPolicyNotification(componentName, componentVersionName, policyStatusReport, Collections.singletonList(repoKeyPath.get()));
+                String componentVersionUrl = componentVersionStatus.getComponentVersion();
+                String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId(componentVersionUrl);
+
+                ProcessedPolicyNotification processedNotification = new ProcessedPolicyNotification(componentName, componentVersionName, componentVersionId, policyStatusReport, Collections.singletonList(repoKeyPath.get()));
                 processedPolicyNotifications.add(processedNotification);
             }
         }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/ProcessedPolicyNotification.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/ProcessedPolicyNotification.java
@@ -16,12 +16,14 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.P
 public class ProcessedPolicyNotification {
     private final String componentName;
     private final String componentVersionName;
+    private final String componentVersionId;
     private final PolicyStatusReport policyStatusReport;
     private final List<RepoPath> affectedRepoKeyPaths;
 
-    public ProcessedPolicyNotification(String componentName, String componentVersionName, PolicyStatusReport policyStatusReport, List<RepoPath> affectedRepoKeyPaths) {
+    public ProcessedPolicyNotification(String componentName, String componentVersionName, String componentVersionId, PolicyStatusReport policyStatusReport, List<RepoPath> affectedRepoKeyPaths) {
         this.componentName = componentName;
         this.componentVersionName = componentVersionName;
+        this.componentVersionId = componentVersionId;
         this.policyStatusReport = policyStatusReport;
         this.affectedRepoKeyPaths = affectedRepoKeyPaths;
     }
@@ -32,6 +34,10 @@ public class ProcessedPolicyNotification {
 
     public String getComponentVersionName() {
         return componentVersionName;
+    }
+
+    public String getComponentVersionId() {
+        return componentVersionId;
     }
 
     public PolicyStatusReport getPolicyStatusReport() {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/ProcessedVulnerabilityNotification.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/ProcessedVulnerabilityNotification.java
@@ -16,12 +16,14 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.notific
 public class ProcessedVulnerabilityNotification {
     private final String componentName;
     private final String componentVersionName;
+    private final String componentVersionId;
     private final List<RepoPath> affectedRepoKeyPaths;
     private final VulnerabilityAggregate vulnerabilityAggregate;
 
-    public ProcessedVulnerabilityNotification(String componentName, String componentVersionName, List<RepoPath> affectedRepoKeyPaths, VulnerabilityAggregate vulnerabilityAggregate) {
+    public ProcessedVulnerabilityNotification(String componentName, String componentVersionName, String componentVersionId, List<RepoPath> affectedRepoKeyPaths, VulnerabilityAggregate vulnerabilityAggregate) {
         this.componentName = componentName;
         this.componentVersionName = componentVersionName;
+        this.componentVersionId = componentVersionId;
         this.affectedRepoKeyPaths = affectedRepoKeyPaths;
         this.vulnerabilityAggregate = vulnerabilityAggregate;
     }
@@ -32,6 +34,10 @@ public class ProcessedVulnerabilityNotification {
 
     public String getComponentVersionName() {
         return componentVersionName;
+    }
+
+    public String getComponentVersionId() {
+        return componentVersionId;
     }
 
     public List<RepoPath> getAffectedRepoKeyPaths() {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/VulnerabilityProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/VulnerabilityProcessor.java
@@ -18,9 +18,9 @@ import com.synopsys.integration.blackduck.api.generated.view.ComponentVersionVie
 import com.synopsys.integration.blackduck.api.generated.view.VulnerabilityView;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilityNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.VulnerabilityNotificationUserView;
-import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.VulnerabilityNotificationService;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.model.VulnerabilityAggregate;
 import com.synopsys.integration.exception.IntegrationException;
 import com.synopsys.integration.util.NameVersion;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/VulnerabilityProcessor.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/processor/VulnerabilityProcessor.java
@@ -18,6 +18,7 @@ import com.synopsys.integration.blackduck.api.generated.view.ComponentVersionVie
 import com.synopsys.integration.blackduck.api.generated.view.VulnerabilityView;
 import com.synopsys.integration.blackduck.api.manual.component.VulnerabilityNotificationContent;
 import com.synopsys.integration.blackduck.api.manual.view.VulnerabilityNotificationUserView;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.RepositoryProjectNameLookup;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.VulnerabilityNotificationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.model.VulnerabilityAggregate;
@@ -54,9 +55,11 @@ public class VulnerabilityProcessor {
             String componentName = content.getComponentName();
             ComponentVersionView componentVersionView = vulnerabilityNotificationService.fetchComponentVersionView(content);
             String componentVersionName = componentVersionView.getVersionName();
+            String componentVersionUrl = content.getComponentVersion();
+            String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId(componentVersionUrl);
             List<VulnerabilityView> vulnerabilityViews = vulnerabilityNotificationService.fetchVulnerabilitiesForComponent(componentVersionView);
             VulnerabilityAggregate vulnerabilityAggregate = VulnerabilityAggregate.fromVulnerabilityViews(vulnerabilityViews);
-            processedNotification = new ProcessedVulnerabilityNotification(componentName, componentVersionName, affectRepoKeyPaths, vulnerabilityAggregate);
+            processedNotification = new ProcessedVulnerabilityNotification(componentName, componentVersionName, componentVersionId, affectRepoKeyPaths, vulnerabilityAggregate);
         }
 
         return Optional.ofNullable(processedNotification);

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/ArtifactInspectionService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/ArtifactInspectionService.java
@@ -30,7 +30,7 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.A
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.ComponentViewWrapper;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.InspectionStatus;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
-import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.model.VulnerabilityAggregate;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.service.util.ArtifactoryComponentService;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/ArtifactInspectionService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/ArtifactInspectionService.java
@@ -30,6 +30,7 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.A
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.ComponentViewWrapper;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.InspectionStatus;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.model.PolicyStatusReport;
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.ComponentVersionIdUtil;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.model.VulnerabilityAggregate;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.service.util.ArtifactoryComponentService;
 import com.synopsys.integration.blackduck.service.BlackDuckApiClient;
@@ -184,10 +185,11 @@ public class ArtifactInspectionService {
         inspectionPropertyService.setInspectionStatus(repoPath, InspectionStatus.SUCCESS);
         inspectionPropertyService.deleteProperty(repoPath, BlackDuckArtifactoryProperty.BLACKDUCK_FORGE, logger);
         inspectionPropertyService.deleteProperty(repoPath, BlackDuckArtifactoryProperty.BLACKDUCK_ORIGIN_ID, logger);
+        inspectionPropertyService.deleteProperty(repoPath, BlackDuckArtifactoryProperty.COMPONENT_NAME_VERSION, logger);
 
-        String componentName = componentViewWrapper.getProjectVersionComponentView().getComponentName();
-        String componentVersionName = componentViewWrapper.getProjectVersionComponentView().getComponentVersionName();
-        inspectionPropertyService.setExternalIdProperties(repoPath, componentName, componentVersionName);
+        String componentVersionUrl = componentViewWrapper.getProjectVersionComponentView().getComponentVersion();
+        String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId(componentVersionUrl);
+        inspectionPropertyService.setExternalIdProperties(repoPath, componentVersionId);
     }
 
     private boolean shouldPerformDeltaAnalysis(RepoPath repoPath) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/InspectionPropertyService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/InspectionPropertyService.java
@@ -48,11 +48,11 @@ public class InspectionPropertyService extends ArtifactoryPropertyService {
     }
 
     public boolean hasExternalIdProperties(RepoPath repoPath) {
-        return hasProperty(repoPath, BlackDuckArtifactoryProperty.COMPONENT_NAME_VERSION);
+        return hasProperty(repoPath, BlackDuckArtifactoryProperty.COMPONENT_VERSION_ID);
     }
 
-    public void setExternalIdProperties(RepoPath repoPath, String componentName, String componentVersionName) {
-        setProperty(repoPath, BlackDuckArtifactoryProperty.COMPONENT_NAME_VERSION, String.format(COMPONENT_NAME_VERSION_FORMAT, componentName, componentVersionName), logger);
+    public void setExternalIdProperties(RepoPath repoPath, String componentVersionId) {
+        setProperty(repoPath, BlackDuckArtifactoryProperty.COMPONENT_VERSION_ID, componentVersionId, logger);
     }
 
     public boolean shouldRetryInspection(RepoPath repoPath) {

--- a/blackduck-artifactory-common/src/test/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtilTest.java
+++ b/blackduck-artifactory-common/src/test/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtilTest.java
@@ -1,0 +1,23 @@
+package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+import com.synopsys.integration.exception.IntegrationException;
+
+class ComponentVersionIdUtilTest {
+
+    @Test
+    void extractComponentVersionId() throws IntegrationException {
+        String expectedComponentVersionId = "e7142eee-d1a2-4b8e-ba87-01f84ac82b1f";
+        String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId("https://blackduck.synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/versions/" + expectedComponentVersionId);
+        assertEquals(expectedComponentVersionId, componentVersionId);
+    }
+
+    @Test
+    void extractComponentVersionIdThrows() {
+        assertThrows(IntegrationException.class, () -> ComponentVersionIdUtil.extractComponentVersionId("https://blackduck.synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/"));
+    }
+}

--- a/blackduck-artifactory-common/src/test/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtilTest.java
+++ b/blackduck-artifactory-common/src/test/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtilTest.java
@@ -1,7 +1,6 @@
 package com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,15 +9,25 @@ import com.synopsys.integration.exception.IntegrationException;
 
 class ComponentVersionIdUtilTest {
 
+    private final static String DUMMY_ID = "08f3bea3-fbfb-4f01-97dd-3f49419f3ea9";
+
     @Test
     void extractComponentVersionId() throws IntegrationException {
         String expectedComponentVersionId = "e7142eee-d1a2-4b8e-ba87-01f84ac82b1f";
-        String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId("https://blackduck.synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/versions/" + expectedComponentVersionId);
+        String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId(String.format("https://blackduck.synopsys.com/api/components/%s/versions/%s", DUMMY_ID, expectedComponentVersionId));
         assertEquals(expectedComponentVersionId, componentVersionId);
     }
 
     @Test
-    void extractComponentVersionIdThrows() {
-        assertThrows(IntegrationException.class, () -> ComponentVersionIdUtil.extractComponentVersionId("https://blackduck.synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/"));
+    void extractBOMComponentVersionId() throws IntegrationException {
+        String expectedComponentVersionId = "e7142eee-d1a2-4b8e-ba87-01f84ac82b1f";
+        String componentVersionId = ComponentVersionIdUtil.extractComponentVersionId(String.format(
+            "https://blackduck.synopsys.com/api/projects/%s/versions/%s/components/%s/versions/%s",
+            DUMMY_ID,
+            DUMMY_ID,
+            DUMMY_ID,
+            expectedComponentVersionId
+        ));
+        assertEquals(expectedComponentVersionId, componentVersionId);
     }
 }

--- a/blackduck-artifactory-common/src/test/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtilTest.java
+++ b/blackduck-artifactory-common/src/test/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/notifications/ComponentVersionIdUtilTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.Test;
 
+import com.synopsys.integration.blackduck.artifactory.modules.inspection.notifications.deleteme.ComponentVersionIdUtil;
 import com.synopsys.integration.exception.IntegrationException;
 
 class ComponentVersionIdUtilTest {

--- a/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/ArtifactNotificationServiceTest.java
+++ b/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/ArtifactNotificationServiceTest.java
@@ -65,30 +65,52 @@ class ArtifactNotificationServiceTest {
 
         String policyOverrideComponentName = "policy-override-component";
         String policyOverrideComponentVersion = "1.0";
+        String policyOverrideComponentVersionId = "8297c696-caf9-4c03-88d7-876964b32acb";
         RepoPath policyOverrideComponentRepoPath = repoPathFactory.create(repoKeyPath1.getRepoKey(), policyOverrideComponentName);
         PolicyStatusReport policyOverrideStatusReport = new PolicyStatusReport(ProjectVersionComponentPolicyStatusType.IN_VIOLATION_OVERRIDDEN, Collections.singletonList(PolicyRuleSeverityType.BLOCKER));
-        ProcessedPolicyNotification processedPolicyOverrideNotification = new ProcessedPolicyNotification(policyOverrideComponentName, policyOverrideComponentVersion, policyOverrideStatusReport, toBeAffectedRepoKeys);
-        Mockito.when(artifactSearchService.findArtifactsUsingComponentNameVersions(policyOverrideComponentName, policyOverrideComponentVersion, toBeAffectedRepoKeys))
+        ProcessedPolicyNotification processedPolicyOverrideNotification = new ProcessedPolicyNotification(
+            policyOverrideComponentName,
+            policyOverrideComponentVersion,
+            policyOverrideComponentVersionId,
+            policyOverrideStatusReport,
+            toBeAffectedRepoKeys
+        );
+        Mockito.when(artifactSearchService.findArtifactsWithComponentVersionId(policyOverrideComponentVersionId, toBeAffectedRepoKeys))
             .thenReturn(Collections.singletonList(policyOverrideComponentRepoPath));
 
         String policyClearedComponentName = "policy-cleared-component";
         String policyClearedComponentVersion = "2.0";
+        String policyClearedComponentVersionId = "1234c696-caf9-4c03-88d7-876964b32acb";
         RepoPath policyClearedComponentRepoPath = repoPathFactory.create(repoKeyPath1.getRepoKey(), policyClearedComponentName);
         PolicyStatusReport policyClearedStatusReport = new PolicyStatusReport(ProjectVersionComponentPolicyStatusType.NOT_IN_VIOLATION, Collections.emptyList());
-        ProcessedPolicyNotification processedPolicyClearedNotification = new ProcessedPolicyNotification(policyClearedComponentName, policyClearedComponentVersion, policyClearedStatusReport, toBeAffectedRepoKeys);
-        Mockito.when(artifactSearchService.findArtifactsUsingComponentNameVersions(policyClearedComponentName, policyClearedComponentVersion, toBeAffectedRepoKeys))
+        ProcessedPolicyNotification processedPolicyClearedNotification = new ProcessedPolicyNotification(
+            policyClearedComponentName,
+            policyClearedComponentVersion,
+            policyClearedComponentVersionId,
+            policyClearedStatusReport,
+            toBeAffectedRepoKeys
+        );
+        Mockito.when(artifactSearchService.findArtifactsWithComponentVersionId(policyClearedComponentVersionId, toBeAffectedRepoKeys))
             .thenReturn(Collections.singletonList(policyClearedComponentRepoPath));
 
         String policyViolationComponentName = "policy-violation-component";
         String policyViolationComponentVersion = "3.0";
+        String policyViolationComponentVersionId = "4321c696-caf9-4c03-88d7-876964b32acb";
         RepoPath policyViolationComponentRepoPath = repoPathFactory.create(repoKeyPath1.getRepoKey(), policyViolationComponentName);
         PolicyStatusReport policyViolationStatusReport = new PolicyStatusReport(ProjectVersionComponentPolicyStatusType.IN_VIOLATION, Collections.singletonList(PolicyRuleSeverityType.BLOCKER));
-        ProcessedPolicyNotification processedPolicyViolationNotification = new ProcessedPolicyNotification(policyViolationComponentName, policyViolationComponentVersion, policyViolationStatusReport, toBeAffectedRepoKeys);
-        Mockito.when(artifactSearchService.findArtifactsUsingComponentNameVersions(policyViolationComponentName, policyViolationComponentVersion, toBeAffectedRepoKeys))
+        ProcessedPolicyNotification processedPolicyViolationNotification = new ProcessedPolicyNotification(
+            policyViolationComponentName,
+            policyViolationComponentVersion,
+            policyViolationComponentVersionId,
+            policyViolationStatusReport,
+            toBeAffectedRepoKeys
+        );
+        Mockito.when(artifactSearchService.findArtifactsWithComponentVersionId(policyViolationComponentVersionId, toBeAffectedRepoKeys))
             .thenReturn(Collections.singletonList(policyViolationComponentRepoPath));
 
         String vulnerableComponentName = "vulnerable-component";
         String vulnerableComponentVersion = "4.0";
+        String vulnerableComponentVersionId = "9876c696-caf9-4c03-88d7-876964b32acb";
         RepoPath vulnerableComponentRepoPath = repoPathFactory.create(repoKeyPath1.getRepoKey(), vulnerableComponentName);
 
         HashMap<VulnerabilitySeverityType, Integer> severityMap = new HashMap<>();
@@ -98,8 +120,14 @@ class ArtifactNotificationServiceTest {
         severityMap.put(VulnerabilitySeverityType.LOW, 1);
         VulnerabilityAggregate vulnerabilityAggregate = new VulnerabilityAggregate(severityMap);
 
-        ProcessedVulnerabilityNotification processedVulnerabilityNotification = new ProcessedVulnerabilityNotification(vulnerableComponentName, vulnerableComponentVersion, toBeAffectedRepoKeys, vulnerabilityAggregate);
-        Mockito.when(artifactSearchService.findArtifactsUsingComponentNameVersions(vulnerableComponentName, vulnerableComponentVersion, toBeAffectedRepoKeys))
+        ProcessedVulnerabilityNotification processedVulnerabilityNotification = new ProcessedVulnerabilityNotification(
+            vulnerableComponentName,
+            vulnerableComponentVersion,
+            vulnerableComponentVersionId,
+            toBeAffectedRepoKeys,
+            vulnerabilityAggregate
+        );
+        Mockito.when(artifactSearchService.findArtifactsWithComponentVersionId(vulnerableComponentVersionId, toBeAffectedRepoKeys))
             .thenReturn(Collections.singletonList(vulnerableComponentRepoPath));
 
         Map<RepoPath, Map<String, String>> propertyMap = new HashMap<>();
@@ -118,8 +146,14 @@ class ArtifactNotificationServiceTest {
         Mockito.when(artifactInspectionService.fetchProjectVersionWrapper(repoKeyPath2.getRepoKey())).thenReturn(projectVersionWrapper);
         Mockito.when(artifactInspectionService.fetchProjectVersionWrapper(deletedProjectRepoKeyPath.getRepoKey())).thenThrow(new IntegrationException("Missing project version in Black Duck."));
 
-        ArtifactNotificationService artifactNotificationService = new ArtifactNotificationService(artifactSearchService, inspectionPropertyService, artifactInspectionService, policyNotificationService, vulnerabilityNotificationService,
-            notificationProcessor);
+        ArtifactNotificationService artifactNotificationService = new ArtifactNotificationService(
+            artifactSearchService,
+            inspectionPropertyService,
+            artifactInspectionService,
+            policyNotificationService,
+            vulnerabilityNotificationService,
+            notificationProcessor
+        );
 
         artifactNotificationService.updateMetadataFromNotifications(Arrays.asList(repoKeyPath1, repoKeyPath2, deletedProjectRepoKeyPath), startDate, endDate);
 

--- a/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/PolicyOverrideProcessorTest.java
+++ b/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/PolicyOverrideProcessorTest.java
@@ -47,6 +47,7 @@ class PolicyOverrideProcessorTest {
         content.setPolicyInfos(Collections.singletonList(new PolicyInfo()));
         content.setComponentName("component-name");
         content.setComponentVersionName("component-version-name-1.0");
+        content.setComponentVersion("https://synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/versions/e7142eee-d1a2-4b8e-ba87-01f84ac82b1f");
         content.setBomComponentVersionPolicyStatus("https://synopsys.com/bomComponentVersionPolicyStatus");
         notificationUserView.setContent(content);
 
@@ -58,6 +59,7 @@ class PolicyOverrideProcessorTest {
 
         Assertions.assertEquals("component-name", processedPolicyNotification.getComponentName());
         Assertions.assertEquals("component-version-name-1.0", processedPolicyNotification.getComponentVersionName());
+        Assertions.assertEquals("e7142eee-d1a2-4b8e-ba87-01f84ac82b1f", processedPolicyNotification.getComponentVersionId());
         Assertions.assertEquals(Collections.singletonList(repoPath), processedPolicyNotification.getAffectedRepoKeyPaths());
         Assertions.assertEquals(Collections.singletonList(PolicyRuleSeverityType.UNSPECIFIED), processedPolicyNotification.getPolicyStatusReport().getPolicyRuleSeverityTypes());
         Assertions.assertEquals(ProjectVersionComponentPolicyStatusType.IN_VIOLATION, processedPolicyNotification.getPolicyStatusReport().getPolicyStatusType());

--- a/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/PolicyRuleClearedProcessorTest.java
+++ b/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/PolicyRuleClearedProcessorTest.java
@@ -50,6 +50,7 @@ class PolicyRuleClearedProcessorTest {
         componentVersionStatus.setComponentName("component-name");
         componentVersionStatus.setComponentVersionName("component-version-name-1.0");
         componentVersionStatus.setBomComponentVersionPolicyStatus("https://synopsys.com/bomComponentVersionPolicyStatus");
+        componentVersionStatus.setComponentVersion("https://synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/versions/e7142eee-d1a2-4b8e-ba87-01f84ac82b1f");
         content.setComponentVersionStatuses(Collections.singletonList(componentVersionStatus));
         notificationUserView.setContent(content);
 
@@ -61,6 +62,7 @@ class PolicyRuleClearedProcessorTest {
 
         Assertions.assertEquals("component-name", processedPolicyNotification.getComponentName());
         Assertions.assertEquals("component-version-name-1.0", processedPolicyNotification.getComponentVersionName());
+        Assertions.assertEquals("e7142eee-d1a2-4b8e-ba87-01f84ac82b1f", processedPolicyNotification.getComponentVersionId());
         Assertions.assertEquals(Collections.singletonList(repoPath), processedPolicyNotification.getAffectedRepoKeyPaths());
         Assertions.assertEquals(Collections.singletonList(PolicyRuleSeverityType.UNSPECIFIED), processedPolicyNotification.getPolicyStatusReport().getPolicyRuleSeverityTypes());
         Assertions.assertEquals(ProjectVersionComponentPolicyStatusType.NOT_IN_VIOLATION, processedPolicyNotification.getPolicyStatusReport().getPolicyStatusType());

--- a/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/PolicyViolationProcessorTest.java
+++ b/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/PolicyViolationProcessorTest.java
@@ -49,6 +49,7 @@ class PolicyViolationProcessorTest {
         ComponentVersionStatus componentVersionStatus = new ComponentVersionStatus();
         componentVersionStatus.setComponentName("component-name");
         componentVersionStatus.setComponentVersionName("component-version-name-1.0");
+        componentVersionStatus.setComponentVersion("https://synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/versions/e7142eee-d1a2-4b8e-ba87-01f84ac82b1f");
         componentVersionStatus.setBomComponentVersionPolicyStatus("https://synopsys.com/bomComponentVersionPolicyStatus");
         content.setComponentVersionStatuses(Collections.singletonList(componentVersionStatus));
         notificationUserView.setContent(content);
@@ -61,6 +62,7 @@ class PolicyViolationProcessorTest {
 
         Assertions.assertEquals("component-name", processedPolicyNotification.getComponentName());
         Assertions.assertEquals("component-version-name-1.0", processedPolicyNotification.getComponentVersionName());
+        Assertions.assertEquals("e7142eee-d1a2-4b8e-ba87-01f84ac82b1f", processedPolicyNotification.getComponentVersionId());
         Assertions.assertEquals(Collections.singletonList(repoPath), processedPolicyNotification.getAffectedRepoKeyPaths());
         Assertions.assertEquals(Collections.singletonList(PolicyRuleSeverityType.UNSPECIFIED), processedPolicyNotification.getPolicyStatusReport().getPolicyRuleSeverityTypes());
         Assertions.assertEquals(ProjectVersionComponentPolicyStatusType.IN_VIOLATION, processedPolicyNotification.getPolicyStatusReport().getPolicyStatusType());

--- a/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/VulnerabiityProcessorTest.java
+++ b/blackduck-artifactory-common/src/test/java/modules/inspection/notifications/processor/VulnerabiityProcessorTest.java
@@ -67,7 +67,7 @@ class VulnerabiityProcessorTest {
         content.setAffectedProjectVersions(Collections.singletonList(affectedProjectVersion));
         content.setComponentName("component-name");
         content.setComponentVersion("component/version/url");
-
+        content.setComponentVersion("https://synopsys.com/api/components/08f3bea3-fbfb-4f01-97dd-3f49419f3ea9/versions/e7142eee-d1a2-4b8e-ba87-01f84ac82b1f");
         notificationUserView.setContent(content);
 
         List<ProcessedVulnerabilityNotification> processedVulnerabilityNotifications = vulnerabilityProcessor.processVulnerabilityNotifications(Collections.singletonList(notificationUserView), repositoryFilter);
@@ -78,6 +78,7 @@ class VulnerabiityProcessorTest {
 
         Assertions.assertEquals("component-name", processedVulnerabilityNotification.getComponentName());
         Assertions.assertEquals("component-version-name-1.0", processedVulnerabilityNotification.getComponentVersionName());
+        Assertions.assertEquals("e7142eee-d1a2-4b8e-ba87-01f84ac82b1f", processedVulnerabilityNotification.getComponentVersionId());
         Assertions.assertEquals(Collections.singletonList(repoPath), processedVulnerabilityNotification.getAffectedRepoKeyPaths());
         VulnerabilityAggregate aggregate = processedVulnerabilityNotification.getVulnerabilityAggregate();
         Assertions.assertEquals(2, aggregate.getHighSeverityCount());
@@ -93,7 +94,7 @@ class VulnerabiityProcessorTest {
         VulnerabilityCvss2View cvss2 = new VulnerabilityCvss2View();
         cvss2.setSeverity(severityType);
         vulnerabilityView.setCvss2(cvss2);
-        
+
         return vulnerabilityView;
     }
 }

--- a/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/InspectionPropertyServiceTest.kt
+++ b/blackduck-artifactory-common/src/test/kotlin/com/synopsys/integration/blackduck/artifactory/modules/inspection/service/InspectionPropertyServiceTest.kt
@@ -48,7 +48,7 @@ class InspectionPropertyServiceTest {
         val artifactoryPAPIService = mock<ArtifactoryPAPIService>()
         val inspectionPropertyService = createInspectionPropertyService(artifactoryPAPIService)
 
-        whenever(artifactoryPAPIService.hasProperty(repoPath, BlackDuckArtifactoryProperty.COMPONENT_NAME_VERSION.propertyName)).thenReturn(true)
+        whenever(artifactoryPAPIService.hasProperty(repoPath, BlackDuckArtifactoryProperty.COMPONENT_VERSION_ID.propertyName)).thenReturn(true)
         Assertions.assertTrue(inspectionPropertyService.hasExternalIdProperties(repoPath))
     }
 
@@ -58,15 +58,16 @@ class InspectionPropertyServiceTest {
 
         val repoPathPropertyMap = mutableMapOf<RepoPath, PropertiesMap>()
         val artifactoryPAPIService = createMockArtifactoryPAPIService(repoPathPropertyMap)
-        val componentNameProperty = BlackDuckArtifactoryProperty.COMPONENT_NAME_VERSION.propertyName
+        val componentVersionIdProperty = BlackDuckArtifactoryProperty.COMPONENT_VERSION_ID.propertyName
+        val componentVersionId = "9876c696-caf9-4c03-88d7-876964b32acb";
 
         val inspectionPropertyService = createInspectionPropertyService(artifactoryPAPIService)
-        inspectionPropertyService.setExternalIdProperties(repoPath, "ComponentName", "ComponentVersionName")
+        inspectionPropertyService.setExternalIdProperties(repoPath, componentVersionId)
 
         val propertyMap = repoPathPropertyMap[repoPath]!!
 
-        Assertions.assertTrue(propertyMap.containsKey(componentNameProperty), "The $componentNameProperty is missing from the properties.")
-        Assertions.assertEquals(String.format(InspectionPropertyService.COMPONENT_NAME_VERSION_FORMAT, "ComponentName", "ComponentVersionName"), propertyMap[componentNameProperty])
+        Assertions.assertTrue(propertyMap.containsKey(componentVersionIdProperty), "The $componentVersionIdProperty is missing from the properties.")
+        Assertions.assertEquals(componentVersionId, propertyMap[componentVersionIdProperty])
     }
 
     @Test


### PR DESCRIPTION
IARTH-449 has exposed an issue with using a component's name/version to identify it. If the Knowledge Base changes the name of a component, artifacts will no longer be updated when notifications are created pertaining to that component.

Since name changes can happen on any component at any time, we must pivot away from using the `blackduck.componentNameVersion` in favor of a new property, `blackduck.componentVersionId` .

The component version id is the only data consistent from when we add components to the BOM, to when we get notifications from BlackDuck.