### PR TITLE
Allow user override of project and version through blackDuckProperties

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/ScanModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/ScanModuleConfig.java
@@ -41,6 +41,8 @@ public class ScanModuleConfig extends ModuleConfig {
     private final Boolean policyBlockedEnabled;
     private final List<String> policyRepos;
     private final List<PolicyRuleSeverityType> policySeverityTypes;
+    private final String overrideProject;
+    private final String overrideVersion;
 
     private final DateTimeManager dateTimeManager;
 
@@ -61,7 +63,9 @@ public class ScanModuleConfig extends ModuleConfig {
         Boolean policyBlockedEnabled,
         List<String> policyRepos,
         List<PolicyRuleSeverityType> policySeverityTypes,
-        DateTimeManager dateTimeManager
+        DateTimeManager dateTimeManager,
+        String overrideProject,
+        String overrideVersion
     ) {
         super(ScanModule.class.getSimpleName(), enabled);
         this.cron = cron;
@@ -79,6 +83,8 @@ public class ScanModuleConfig extends ModuleConfig {
         this.policyRepos = policyRepos;
         this.policySeverityTypes = policySeverityTypes;
         this.dateTimeManager = dateTimeManager;
+        this.overrideProject = overrideProject;
+        this.overrideVersion = overrideVersion;
     }
 
     public static ScanModuleConfig createFromProperties(
@@ -126,6 +132,16 @@ public class ScanModuleConfig extends ModuleConfig {
                                                                .map(PolicyRuleSeverityType::valueOf)
                                                                .collect(Collectors.toList());
 
+        String overrideProject = configurationPropertyManager.getProperty(ScanModuleProperty.OVERRIDE_PROJECT);
+        if (overrideProject != null && !overrideProject.isEmpty()) {
+            logger.info(String.format("Found project override property for scans. Project override: %s", overrideProject));
+        }
+
+        String overrideVersion = configurationPropertyManager.getProperty(ScanModuleProperty.OVERRIDE_VERSION);
+        if (overrideVersion != null && !overrideVersion.isEmpty()) {
+            logger.info(String.format("Found version override property for scans. Version override: %s", overrideVersion));
+        }
+
         return new ScanModuleConfig(
             enabled,
             cron,
@@ -142,7 +158,9 @@ public class ScanModuleConfig extends ModuleConfig {
             policyBlockedEnabled,
             policyRepos,
             policySeverityTypes,
-            dateTimeManager
+            dateTimeManager,
+            overrideProject,
+            overrideVersion
         );
     }
 
@@ -239,5 +257,13 @@ public class ScanModuleConfig extends ModuleConfig {
 
     public List<String> getMetadataBlockRepos() {
         return metadataBlockRepos;
+    }
+
+    public String getOverrideProject() {
+        return overrideProject;
+    }
+
+    public String getOverrideVersion() {
+        return overrideVersion;
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/ScanModuleProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/ScanModuleProperty.java
@@ -21,6 +21,8 @@ public enum ScanModuleProperty implements ConfigurationProperty {
     METADATA_BLOCK_REPOS("metadata.block.repos"),
     METADATA_BLOCK_REPOS_CSV_PATH("metadata.block.repos.csv.path"),
     NAME_PATTERNS("name.patterns"),
+    OVERRIDE_PROJECT("override.project"),
+    OVERRIDE_VERSION("override.version"),
     POLICY_BLOCK("policy.block"),
     POLICY_REPOS("policy.repos"),
     POLICY_REPOS_CSV_PATH("policy.repos.csv.path"),

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/service/ArtifactScanService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/service/ArtifactScanService.java
@@ -186,6 +186,18 @@ public class ArtifactScanService {
         String version = artifactoryPropertyService.getProperty(repoPath, BlackDuckArtifactoryProperty.BLACKDUCK_PROJECT_VERSION_NAME)
                              .orElse(fileLayoutInfo.getBaseRevision());
 
+        String overrideProject = scanModuleConfig.getOverrideProject();
+        if (overrideProject != null && !overrideProject.isEmpty()) {
+            logger.info(String.format("Overriding project. Original project: %s, Override project: %s", project, overrideProject));
+            project = overrideProject;
+        }
+
+        String overrideVersion = scanModuleConfig.getOverrideVersion();
+        if (overrideVersion != null && !overrideVersion.isEmpty()) {
+            logger.info(String.format("Overriding version. Original version: %s, Override version: %s", version, overrideVersion));
+            version = overrideVersion;
+        }
+
         boolean missingProjectName = StringUtils.isBlank(project);
         boolean missingProjectVersionName = StringUtils.isBlank(version);
         if (missingProjectName || missingProjectVersionName) {

--- a/src/main/resources/blackDuckPlugin.properties
+++ b/src/main/resources/blackDuckPlugin.properties
@@ -34,6 +34,9 @@ blackduck.artifactory.scan.cron=0 0/1 * 1/1 * ?
 blackduck.artifactory.scan.metadata.block=false
 blackduck.artifactory.scan.metadata.block.repos=
 blackduck.artifactory.scan.metadata.block.repos.csv.path=
+# If override.project/override.version is set, the plugin will override project / version to the specified ones for all repositories scanned
+blackduck.artifactory.scan.override.project=
+blackduck.artifactory.scan.override.version=
 # If policy.repos/policy.repos.csv.path is left blank, or not contained within scan.repos/scan.repos.csv.path, all scanned repositories will be used.
 blackduck.artifactory.scan.policy.block=true
 blackduck.artifactory.scan.policy.repos=


### PR DESCRIPTION
Use case: when we scan a directory of packages, the default ends up creating a single version for each component (which results in far too many components). We are scanning a remote repository, so we don't have the option of setting repo level properties -- Artifactory only allows users to set properties on the remote cache, not the remote repo itself (which is the first point of contact for downloads, hence resulting in the remote cache repo's properties not being read) or virtual repos.

This allows users to just set
```
blackduck.artifactory.scan.override.project=<override-project-string>
blackduck.artifactory.scan.override.version=<override-version-string>
```

in the blackDuckPlugin.properties file and have those apply to all scans.

Why we're scanning remote repos: long story, but blackduck doesn't support R libraries out of the box. We have an ongoing thread with a rep from Synopsys, but it doesn't look like this functionality is supported fully. Fortunately, R packages are mostly .tar.gz wrappers around c++ / javascript / fortran libraries, so it's sufficient to just scan those .tar.gz packages. Hence we're scanning a remote repo.