### PR TITLE
Enhance for SCA-as-a-Service

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,1 +1,202 @@
-Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/blackduck-artifactory-common/build.gradle
+++ b/blackduck-artifactory-common/build.gradle
@@ -10,6 +10,7 @@ plugins {
 
 apply plugin: 'com.synopsys.integration.simple'
 apply plugin: 'kotlin'
+apply plugin: 'java-library'
 
 jar.finalizedBy shadowJar
 

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
@@ -37,7 +37,8 @@ public enum BlackDuckArtifactoryProperty {
     POST_SCAN_ACTION_STATUS("postScanActionStatus"),
     POST_SCAN_PHASE("postScanPhase"),
     INSPECTION_RETRY_COUNT("inspectionRetryCount"),
-    SCAN_STATUS("scaas.inspectionStatus");
+    SCAAAS_SCAN_STATUS("scaass.artifactory.inspectionStatus"),
+    SCAAAS_POLICY_STATUS("scaaas.artifactory.policyStatus");
 
     private final String propertyName;
     private final String timeName;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
@@ -37,8 +37,8 @@ public enum BlackDuckArtifactoryProperty {
     POST_SCAN_ACTION_STATUS("postScanActionStatus"),
     POST_SCAN_PHASE("postScanPhase"),
     INSPECTION_RETRY_COUNT("inspectionRetryCount"),
-    SCAAAS_SCAN_STATUS("scaass.artifactory.inspectionStatus"),
-    SCAAAS_POLICY_STATUS("scaaas.artifactory.policyStatus");
+    SCAAAS_SCAN_STATUS("scaaas.inspectionStatus"),
+    SCAAAS_POLICY_STATUS("scaaas.policyStatus");
 
     private final String propertyName;
     private final String timeName;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
@@ -36,7 +36,8 @@ public enum BlackDuckArtifactoryProperty {
     SCAN_RESULT_MESSAGE("scanResultMessage"),
     POST_SCAN_ACTION_STATUS("postScanActionStatus"),
     POST_SCAN_PHASE("postScanPhase"),
-    INSPECTION_RETRY_COUNT("inspectionRetryCount");
+    INSPECTION_RETRY_COUNT("inspectionRetryCount"),
+    SCAN_STATUS("scanStatus");
 
     private final String propertyName;
     private final String timeName;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-artifactory-common
  *
- * Copyright (c) 2021 Synopsys, Inc.
+ * Copyright (c) 2022 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
@@ -37,7 +37,7 @@ public enum BlackDuckArtifactoryProperty {
     POST_SCAN_ACTION_STATUS("postScanActionStatus"),
     POST_SCAN_PHASE("postScanPhase"),
     INSPECTION_RETRY_COUNT("inspectionRetryCount"),
-    SCAN_STATUS("scanStatus");
+    SCAN_STATUS("scaas.inspectionStatus");
 
     private final String propertyName;
     private final String timeName;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/PluginService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/PluginService.java
@@ -93,6 +93,13 @@ public class PluginService {
 
         moduleManager.registerModules(scanModule, inspectionModule, analyticsModule, scanAsAServiceModule);
 
+        if (scanAsAServiceModule.getModuleConfig().isEnabled()) {
+            logger.info(String.format("%s module enabled. Disabling %s and %s modules",
+                    scanAsAServiceModule.getModuleConfig().getModuleName(), scanModule.getModuleConfig().getModuleName(), inspectionModule.getModuleConfig().getModuleName()));
+            scanModule.getModuleConfig().setEnabled(false);
+            inspectionModule.getModuleConfig().setEnabled(false);
+        }
+
         configValidationService = new ConfigValidationService(moduleManager, pluginConfig, directoryConfig.getVersionFile());
         ConfigValidationReport configValidationReport = configValidationService.validateConfig();
         if (configValidationReport.getGeneralPropertyReport().hasError()) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/PluginService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/PluginService.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-artifactory-common
  *
- * Copyright (c) 2021 Synopsys, Inc.
+ * Copyright (c) 2022 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
@@ -31,6 +31,7 @@ import com.synopsys.integration.blackduck.artifactory.modules.analytics.Analytic
 import com.synopsys.integration.blackduck.artifactory.modules.analytics.collector.FeatureAnalyticsCollector;
 import com.synopsys.integration.blackduck.artifactory.modules.analytics.service.AnalyticsService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.InspectionModule;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModule;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanModule;
 import com.synopsys.integration.blackduck.configuration.BlackDuckServerConfig;
 import com.synopsys.integration.blackduck.service.BlackDuckServicesFactory;
@@ -88,8 +89,9 @@ public class PluginService {
         ScanModule scanModule = moduleFactory.createScanModule();
         InspectionModule inspectionModule = moduleFactory.createInspectionModule();
         AnalyticsModule analyticsModule = moduleFactory.createAnalyticsModule(analyticsService, moduleManager);
+        ScanAsAServiceModule scanAsAServiceModule = moduleFactory.createScanAsAServiceModule();
 
-        moduleManager.registerModules(scanModule, inspectionModule, analyticsModule);
+        moduleManager.registerModules(scanModule, inspectionModule, analyticsModule, scanAsAServiceModule);
 
         configValidationService = new ConfigValidationService(moduleManager, pluginConfig, directoryConfig.getVersionFile());
         ConfigValidationReport configValidationReport = configValidationService.validateConfig();
@@ -102,7 +104,7 @@ public class PluginService {
         logger.warn(statusCheckMessage);
 
         FeatureAnalyticsCollector featureAnalyticsCollector = new FeatureAnalyticsCollector(PluginAPI.class);
-        PluginAPI pluginAPI = new PluginAPI(featureAnalyticsCollector, moduleManager, scanModule, inspectionModule, analyticsModule);
+        PluginAPI pluginAPI = new PluginAPI(featureAnalyticsCollector, moduleManager, scanModule, inspectionModule, analyticsModule, scanAsAServiceModule);
         analyticsService.registerAnalyzable(pluginAPI);
 
         logger.info("...blackDuckPlugin initialized.");

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/configuration/ConfigValidationService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/configuration/ConfigValidationService.java
@@ -24,6 +24,7 @@ import com.synopsys.integration.blackduck.artifactory.configuration.model.Proper
 import com.synopsys.integration.blackduck.artifactory.configuration.model.PropertyValidationResult;
 import com.synopsys.integration.blackduck.artifactory.modules.ModuleConfig;
 import com.synopsys.integration.blackduck.artifactory.modules.ModuleManager;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModule;
 import com.synopsys.integration.builder.BuilderStatus;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.log.Slf4jIntLogger;
@@ -48,13 +49,14 @@ public class ConfigValidationService {
     public ConfigValidationReport validateConfig() {
         BuilderStatus generalBuilderStatus = new BuilderStatus();
         PropertyGroupReport generalPropertyReport = new PropertyGroupReport("General Settings", generalBuilderStatus);
-        pluginConfig.validate(generalPropertyReport);
+        List<String> enabedModules = moduleManager.getAllEnabledModules();
+        pluginConfig.validate(generalPropertyReport, enabedModules);
 
         List<PropertyGroupReport> propertyGroupReports = new ArrayList<>();
         for (ModuleConfig moduleConfig : moduleManager.getAllModuleConfigs()) {
             BuilderStatus propertyGroupBuilderStatus = new BuilderStatus();
             PropertyGroupReport propertyGroupReport = new PropertyGroupReport(moduleConfig.getModuleName(), propertyGroupBuilderStatus);
-            moduleConfig.validate(propertyGroupReport);
+            moduleConfig.validate(propertyGroupReport, enabedModules);
             propertyGroupReports.add(propertyGroupReport);
         }
 

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/configuration/ConfigurationValidator.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/configuration/ConfigurationValidator.java
@@ -17,7 +17,7 @@ import com.synopsys.integration.blackduck.artifactory.configuration.model.Proper
 import com.synopsys.integration.blackduck.artifactory.configuration.model.PropertyValidationResult;
 
 public abstract class ConfigurationValidator {
-    public abstract void validate(PropertyGroupReport propertyGroupReport);
+    public abstract void validate(PropertyGroupReport propertyGroupReport, List<String> enabledModuleNames);
 
     protected void validateDate(PropertyGroupReport statusReport, ConfigurationProperty property, String date, DateTimeManager dateTimeManager) {
         if (StringUtils.isNotBlank(date) && dateTimeManager != null) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/configuration/ConfigurationValidator.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/configuration/ConfigurationValidator.java
@@ -21,10 +21,15 @@ public abstract class ConfigurationValidator {
 
     protected void validateDate(PropertyGroupReport statusReport, ConfigurationProperty property, String date, DateTimeManager dateTimeManager) {
         if (StringUtils.isNotBlank(date) && dateTimeManager != null) {
+            boolean passed = true;
             try {
                 dateTimeManager.getDateFromString(date);
             } catch (DateTimeParseException ignored) {
                 statusReport.addErrorMessage(property, String.format("Property %s is set to %s which does not match the format %s", property.getKey(), date, dateTimeManager.getDateTimePattern()));
+                passed = false;
+            }
+            if (passed) {
+                statusReport.addPropertyValidationReport(new PropertyValidationResult(property));
             }
         } else if (StringUtils.isBlank(date)) {
             statusReport.addErrorMessage(property, String.format("Property %s is not set", property.getKey()));

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
@@ -204,7 +204,7 @@ public class ModuleFactory {
     }
 
     public ScanAsAServiceModule createScanAsAServiceModule() throws IOException {
-        ScanAsAServiceModuleConfig scanAsAServiceModuleConfig = ScanAsAServiceModuleConfig.createFromProperties(configurationPropertyManager, artifactoryPAPIService);
+        ScanAsAServiceModuleConfig scanAsAServiceModuleConfig = ScanAsAServiceModuleConfig.createFromProperties(configurationPropertyManager, artifactoryPAPIService, dateTimeManager);
         ScanAsAServicePropertyService scanAsAServicePropertyService = new ScanAsAServicePropertyService(artifactoryPAPIService, dateTimeManager);
         ScanAsAServiceCancelDecider scanAsAServiceCancelDecider = new ScanAsAServiceCancelDecider(scanAsAServiceModuleConfig, scanAsAServicePropertyService, artifactoryPAPIService);
         return new ScanAsAServiceModule(scanAsAServiceModuleConfig,

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
@@ -26,6 +26,7 @@ import com.synopsys.integration.blackduck.artifactory.modules.analytics.service.
 import com.synopsys.integration.blackduck.artifactory.modules.cancel.CancelDecider;
 import com.synopsys.integration.blackduck.artifactory.modules.cancel.InspectionCancelDecider;
 import com.synopsys.integration.blackduck.artifactory.modules.cancel.PolicyCancelDecider;
+import com.synopsys.integration.blackduck.artifactory.modules.cancel.ScanAsAServiceCancelDecider;
 import com.synopsys.integration.blackduck.artifactory.modules.cancel.ScanCancelDecider;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.InspectionModule;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.InspectionModuleConfig;
@@ -52,6 +53,7 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.service
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.service.util.ArtifactoryComponentService;
 import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModule;
 import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModuleConfig;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServicePropertyService;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanModule;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanModuleConfig;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanPropertyService;
@@ -203,6 +205,9 @@ public class ModuleFactory {
 
     public ScanAsAServiceModule createScanAsAServiceModule() throws IOException {
         ScanAsAServiceModuleConfig scanAsAServiceModuleConfig = ScanAsAServiceModuleConfig.createFromProperties(configurationPropertyManager, artifactoryPAPIService);
-        return new ScanAsAServiceModule(scanAsAServiceModuleConfig);
+        ScanAsAServicePropertyService scanAsAServicePropertyService = new ScanAsAServicePropertyService(artifactoryPAPIService, dateTimeManager);
+        ScanAsAServiceCancelDecider scanAsAServiceCancelDecider = new ScanAsAServiceCancelDecider(scanAsAServiceModuleConfig, scanAsAServicePropertyService, artifactoryPAPIService);
+        return new ScanAsAServiceModule(scanAsAServiceModuleConfig,
+                Arrays.asList(scanAsAServiceCancelDecider));
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-artifactory-common
  *
- * Copyright (c) 2021 Synopsys, Inc.
+ * Copyright (c) 2022 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
@@ -50,6 +50,8 @@ import com.synopsys.integration.blackduck.artifactory.modules.inspection.service
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.service.PolicySeverityService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.service.RepositoryInitializationService;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.service.util.ArtifactoryComponentService;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModule;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModuleConfig;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanModule;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanModuleConfig;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanPropertyService;
@@ -197,5 +199,10 @@ public class ModuleFactory {
         SimpleAnalyticsCollector simpleAnalyticsCollector = new SimpleAnalyticsCollector();
 
         return new AnalyticsModule(analyticsModuleConfig, analyticsService, simpleAnalyticsCollector, moduleManager);
+    }
+
+    public ScanAsAServiceModule createScanAsAServiceModule() {
+        ScanAsAServiceModuleConfig scanAsAServiceModuleConfig = ScanAsAServiceModuleConfig.createFromProperties();
+        return new ScanAsAServiceModule(scanAsAServiceModuleConfig);
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
@@ -201,8 +201,8 @@ public class ModuleFactory {
         return new AnalyticsModule(analyticsModuleConfig, analyticsService, simpleAnalyticsCollector, moduleManager);
     }
 
-    public ScanAsAServiceModule createScanAsAServiceModule() {
-        ScanAsAServiceModuleConfig scanAsAServiceModuleConfig = ScanAsAServiceModuleConfig.createFromProperties();
+    public ScanAsAServiceModule createScanAsAServiceModule() throws IOException {
+        ScanAsAServiceModuleConfig scanAsAServiceModuleConfig = ScanAsAServiceModuleConfig.createFromProperties(configurationPropertyManager, artifactoryPAPIService);
         return new ScanAsAServiceModule(scanAsAServiceModuleConfig);
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleManager.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleManager.java
@@ -57,7 +57,7 @@ public class ModuleManager {
         ModuleConfig moduleConfig = module.getModuleConfig();
         BuilderStatus builderStatus = new BuilderStatus();
         PropertyGroupReport propertyGroupReport = new PropertyGroupReport(moduleConfig.getModuleName(), builderStatus);
-        moduleConfig.validate(propertyGroupReport);
+        moduleConfig.validate(propertyGroupReport, getAllEnabledModules());
 
         allModules.add(module);
         if (!propertyGroupReport.hasError()) {
@@ -106,5 +106,12 @@ public class ModuleManager {
 
     public void setAllModulesEnabledState(boolean isModuleEnabled) {
         getAllModuleConfigs().forEach(moduleConfig -> moduleConfig.setEnabled(isModuleEnabled));
+    }
+
+    public List<String> getAllEnabledModules() {
+        return getModuleConfigs().stream()
+                .filter(ModuleConfig::isEnabled)
+                .map(ModuleConfig::getModuleName)
+                .collect(Collectors.toList());
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
@@ -1,7 +1,7 @@
 /*
  * blackduck-artifactory-common
  *
- * Copyright (c) 2021 Synopsys, Inc.
+ * Copyright (c) 2022 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
@@ -24,6 +24,7 @@ import com.synopsys.integration.blackduck.artifactory.modules.analytics.Analyzab
 import com.synopsys.integration.blackduck.artifactory.modules.analytics.collector.AnalyticsCollector;
 import com.synopsys.integration.blackduck.artifactory.modules.analytics.collector.FeatureAnalyticsCollector;
 import com.synopsys.integration.blackduck.artifactory.modules.inspection.InspectionModule;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModule;
 import com.synopsys.integration.blackduck.artifactory.modules.scan.ScanModule;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.log.Slf4jIntLogger;
@@ -42,13 +43,15 @@ public class PluginAPI implements Analyzable {
     private final ScanModule scanModule;
     private final InspectionModule inspectionModule;
     private final AnalyticsModule analyticsModule;
+    private final ScanAsAServiceModule scanAsAServiceModule;
 
-    public PluginAPI(FeatureAnalyticsCollector featureAnalyticsCollector, ModuleManager moduleManager, ScanModule scanModule, InspectionModule inspectionModule, AnalyticsModule analyticsModule) {
+    public PluginAPI(FeatureAnalyticsCollector featureAnalyticsCollector, ModuleManager moduleManager, ScanModule scanModule, InspectionModule inspectionModule, AnalyticsModule analyticsModule, ScanAsAServiceModule scanAsAServiceModule) {
         this.featureAnalyticsCollector = featureAnalyticsCollector;
         this.moduleManager = moduleManager;
         this.scanModule = scanModule;
         this.inspectionModule = inspectionModule;
         this.analyticsModule = analyticsModule;
+        this.scanAsAServiceModule = scanAsAServiceModule;
     }
 
     public void setModuleState(TriggerType triggerType, Map<String, List<String>> params) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
@@ -10,11 +10,13 @@ package com.synopsys.integration.blackduck.artifactory.modules;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
 import org.artifactory.fs.ItemInfo;
 import org.artifactory.repo.RepoPath;
+import org.artifactory.request.Request;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.artifactory.LogUtil;
@@ -159,6 +161,10 @@ public class PluginAPI implements Analyzable {
         return success == null ? "AnalyticsModule disabled" : success.toString();
     }
 
+    public void handleBeforeDownloadEventScanAsAService(TriggerType triggerType, Request request, RepoPath repoPath) {
+        runMethod(scanAsAServiceModule, triggerType, request, repoPath, scanAsAServiceModule::handleBeforeDownloadEvent);
+    }
+
     /**
      * Below are utility methods to help reuse the code for logging and analytics
      */
@@ -166,6 +172,13 @@ public class PluginAPI implements Analyzable {
     private <T> void runMethod(Module module, TriggerType triggerType, T consumable, Consumer<T> consumer) {
         if (startMethodRun(module, triggerType)) {
             consumer.accept(consumable);
+            finishMethodRun(module, triggerType, triggerType);
+        }
+    }
+
+    private <R, T> void runMethod(Module module, TriggerType triggerType, R consumable1, T consumable2, BiConsumer<R, T> consumer) {
+        if (startMethodRun(module, triggerType)) {
+            consumer.accept(consumable1, consumable2);
             finishMethodRun(module, triggerType, triggerType);
         }
     }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/analytics/AnalyticsModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/analytics/AnalyticsModuleConfig.java
@@ -7,6 +7,8 @@
  */
 package com.synopsys.integration.blackduck.artifactory.modules.analytics;
 
+import java.util.List;
+
 import com.synopsys.integration.blackduck.artifactory.configuration.ConfigurationPropertyManager;
 import com.synopsys.integration.blackduck.artifactory.configuration.model.PropertyGroupReport;
 import com.synopsys.integration.blackduck.artifactory.modules.ModuleConfig;
@@ -23,7 +25,7 @@ public class AnalyticsModuleConfig extends ModuleConfig {
     }
 
     @Override
-    public void validate(PropertyGroupReport propertyGroupReport) {
+    public void validate(PropertyGroupReport propertyGroupReport, List<String> enabledModules) {
         validateBoolean(propertyGroupReport, AnalyticsModuleProperty.ENABLED, isEnabledUnverified());
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/CancelDecision.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/CancelDecision.java
@@ -1,11 +1,13 @@
 /*
  * blackduck-artifactory-common
  *
- * Copyright (c) 2021 Synopsys, Inc.
+ * Copyright (c) 2022 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
 package com.synopsys.integration.blackduck.artifactory.modules.cancel;
+
+import java.util.Objects;
 
 import org.jetbrains.annotations.Nullable;
 
@@ -34,6 +36,11 @@ public class CancelDecision {
     @Nullable // null when CancelDecision::shouldCancelDownload is false
     public String getCancelReason() {
         return cancelReason;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(shouldCancelDownload, cancelReason);
     }
 
     @Override

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/CancelDecision.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/CancelDecision.java
@@ -35,4 +35,20 @@ public class CancelDecision {
     public String getCancelReason() {
         return cancelReason;
     }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == this) {
+            return true;
+        }
+
+        if (!(o instanceof CancelDecision)) {
+            return false;
+        }
+
+        CancelDecision c = (CancelDecision) o;
+        return shouldCancelDownload == c.shouldCancelDownload
+                && ((cancelReason == null && c.cancelReason == null)
+                    || (cancelReason != null && cancelReason.equals(c.cancelReason)));
+    }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
@@ -1,23 +1,22 @@
 /*
- * Copyright (C) 2022 Synopsys Inc.
- * http://www.synopsys.com/
- * All rights reserved.
+ * blackduck-artifactory-common
  *
- * This software is the confidential and proprietary information of
- * Synopsys ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Synopsys.
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-
 package com.synopsys.integration.blackduck.artifactory.modules.cancel;
+
+import java.util.Optional;
 
 import org.artifactory.fs.ItemInfo;
 import org.artifactory.repo.RepoPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
 import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.BlackDuckArtifactoryProperty;
 import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceBlockingStrategy;
 import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModuleConfig;
 import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServicePropertyService;
@@ -47,15 +46,15 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
         }
 
         ScanAsAServiceBlockingStrategy blockingStrategy = moduleConfig.getBlockingStrategy();
+        Optional<ProjectVersionComponentPolicyStatusType> policyViolationStatus = propertyService.getOverallPolicyStatus(repoPath);
         return propertyService.getScanStatusProperty(repoPath).map(
                         scanStatus -> {
                             CancelDecision dec;
                             switch (scanStatus) {
                             case FAILED:
-                            case SUCCESS_POLICY_VIOLATION:
                                 dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
                                 break;
-                            case SCAN_IN_PROGRESS:
+                            case PROCESSING:
                                 switch (blockingStrategy) {
                                 case BLOCK_ALL:
                                     dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
@@ -68,10 +67,39 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
                                             String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
                                 }
                                 break;
-                            case SUCCESS_NO_POLICY_VIOLATION:
-                                dec = CancelDecision.NO_CANCELLATION();
+                            case SUCCESS:
+                                if(policyViolationStatus.isPresent()) {
+                                    switch (policyViolationStatus.get()) {
+                                    case NOT_IN_VIOLATION:
+                                        dec = CancelDecision.NO_CANCELLATION();
+                                        break;
+                                    case IN_VIOLATION:
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", scanStatus.getMessage(), policyViolationStatus.get(), repoPath));
+                                        break;
+                                    default:
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                String.format("Download blocked; %s; Unknown policy violation status: %s; repo: %s", scanStatus.getMessage(), policyViolationStatus.get(), repoPath));
+                                    }
+                                } else {
+                                    logger.warn(String.format("%s; %s property not present; Using block strategy: %s; repo: %s", scanStatus.getMessage(),
+                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS.getPropertyName(), blockingStrategy, repoPath));
+                                    switch (blockingStrategy) {
+                                    case BLOCK_ALL:
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(
+                                            String.format("Download blocked; %s; %s not present; block strategy: %s; repo: %s", scanStatus.getMessage(), BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                        break;
+                                    case BLOCK_NONE:
+                                        dec = CancelDecision.NO_CANCELLATION();
+                                        break;
+                                    default:
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                String.format("Download blocked; %s not present; Unknown blocking strategy: %s; repo: %s", BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                    }
+                                }
                                 break;
                             default:
+                                logger.warn(String.format("Unknown scan status detected: %s", scanStatus));
                                 dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", scanStatus, repoPath));
                             }
                             return dec;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
@@ -46,7 +46,7 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
         }
 
         ScanAsAServiceBlockingStrategy blockingStrategy = moduleConfig.getBlockingStrategy();
-        Optional<ProjectVersionComponentPolicyStatusType> policyViolationStatus = propertyService.getOverallPolicyStatus(repoPath);
+        Optional<ProjectVersionComponentPolicyStatusType> policyViolationStatus = propertyService.getPolicyStatus(repoPath);
         return propertyService.getScanStatusProperty(repoPath).map(
                         scanStatus -> {
                             CancelDecision dec;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2022 Synopsys Inc.
+ * http://www.synopsys.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Synopsys ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Synopsys.
+ */
+
+package com.synopsys.integration.blackduck.artifactory.modules.cancel;
+
+import org.artifactory.fs.ItemInfo;
+import org.artifactory.repo.RepoPath;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceBlockingStrategy;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModuleConfig;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServicePropertyService;
+
+public class ScanAsAServiceCancelDecider implements CancelDecider {
+    private final Logger logger = LoggerFactory.getLogger(ScanAsAServiceCancelDecider.class);
+
+    private final ScanAsAServiceModuleConfig moduleConfig;
+
+    private final ScanAsAServicePropertyService propertyService;
+
+    private final ArtifactoryPAPIService artifactoryPAPIService;
+
+    public ScanAsAServiceCancelDecider(ScanAsAServiceModuleConfig moduleConfig,
+            ScanAsAServicePropertyService propertyService,
+            ArtifactoryPAPIService artifactoryPAPIService) {
+        this.moduleConfig = moduleConfig;
+        this.propertyService = propertyService;
+        this.artifactoryPAPIService = artifactoryPAPIService;
+    }
+
+    @Override
+    public CancelDecision getCancelDecision(RepoPath repoPath) {
+        ItemInfo itemInfo = artifactoryPAPIService.getItemInfo(repoPath);
+        if (itemInfo.isFolder()) {
+            return CancelDecision.NO_CANCELLATION();
+        }
+
+        ScanAsAServiceBlockingStrategy blockingStrategy = moduleConfig.getBlockingStrategy();
+        return propertyService.getScanStatusProperty(repoPath).map(
+                        scanStatus -> {
+                            CancelDecision dec;
+                            switch (scanStatus) {
+                            case FAILED:
+                            case SUCCESS_POLICY_VIOLATION:
+                                dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
+                                break;
+                            case SCAN_IN_PROGRESS:
+                                switch (blockingStrategy) {
+                                case BLOCK_ALL:
+                                    dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
+                                    break;
+                                case BLOCK_NONE:
+                                    dec = CancelDecision.NO_CANCELLATION();
+                                    break;
+                                default:
+                                    dec = CancelDecision.CANCEL_DOWNLOAD(
+                                            String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                                }
+                                break;
+                            case SUCCESS_NO_POLICY_VIOLATION:
+                                dec = CancelDecision.NO_CANCELLATION();
+                                break;
+                            default:
+                                dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", scanStatus, repoPath));
+                            }
+                            return dec;
+                        })
+                .orElseGet(() ->{
+                        switch (blockingStrategy) {
+                            case BLOCK_ALL:
+                                return CancelDecision.CANCEL_DOWNLOAD(
+                                        String.format("Download blocked; Scan not scheduled and blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                            case BLOCK_NONE:
+                                return CancelDecision.NO_CANCELLATION();
+                            default:
+                                return CancelDecision.CANCEL_DOWNLOAD(
+                                        String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                        }
+                });
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
@@ -41,6 +41,10 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
 
     @Override
     public CancelDecision getCancelDecision(RepoPath repoPath) {
+        if (!moduleConfig.getBlockingRepos().contains(repoPath.getRepoKey())) {
+            return CancelDecision.NO_CANCELLATION();
+        }
+
         ItemInfo itemInfo = artifactoryPAPIService.getItemInfo(repoPath);
         if (itemInfo.isFolder()) {
             return CancelDecision.NO_CANCELLATION();

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/InspectionModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/inspection/InspectionModuleConfig.java
@@ -118,7 +118,7 @@ public class InspectionModuleConfig extends ModuleConfig {
     }
 
     @Override
-    public void validate(PropertyGroupReport propertyGroupReport) {
+    public void validate(PropertyGroupReport propertyGroupReport, List<String> enabledModules) {
         validateBoolean(propertyGroupReport, InspectionModuleProperty.ENABLED, isEnabledUnverified());
         validateCronExpression(propertyGroupReport, InspectionModuleProperty.CRON, inspectionCron);
         validateCronExpression(propertyGroupReport, InspectionModuleProperty.REINSPECT_CRON, reinspectCron);

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceBlockingStrategy.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceBlockingStrategy.java
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2022 Synopsys Inc.
+ * http://www.synopsys.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Synopsys ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Synopsys.
+ */
+
+package com.synopsys.integration.blackduck.artifactory.modules.scaas;
+
+public enum ScanAsAServiceBlockingStrategy {
+    BLOCK_ALL,
+    BLOCK_NONE,
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceBlockingStrategy.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceBlockingStrategy.java
@@ -1,15 +1,10 @@
 /*
- * Copyright (C) 2022 Synopsys Inc.
- * http://www.synopsys.com/
- * All rights reserved.
+ * blackduck-artifactory-common
  *
- * This software is the confidential and proprietary information of
- * Synopsys ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Synopsys.
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-
 package com.synopsys.integration.blackduck.artifactory.modules.scaas;
 
 public enum ScanAsAServiceBlockingStrategy {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModule.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModule.java
@@ -7,12 +7,16 @@
  */
 package com.synopsys.integration.blackduck.artifactory.modules.scaas;
 
+import java.util.Collection;
 import java.util.List;
 
+import org.artifactory.repo.RepoPath;
+import org.artifactory.request.Request;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.artifactory.modules.Module;
 import com.synopsys.integration.blackduck.artifactory.modules.analytics.collector.AnalyticsCollector;
+import com.synopsys.integration.blackduck.artifactory.modules.cancel.CancelDecider;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.log.Slf4jIntLogger;
 
@@ -21,8 +25,12 @@ public class ScanAsAServiceModule implements Module {
 
     private final ScanAsAServiceModuleConfig scanAsAServiceModuleConfig;
 
-    public ScanAsAServiceModule(ScanAsAServiceModuleConfig scanAsAServiceModuleConfig) {
+    private final Collection<CancelDecider> cancelDeciders;
+
+    public ScanAsAServiceModule(ScanAsAServiceModuleConfig scanAsAServiceModuleConfig,
+            Collection<CancelDecider> cancelDeciders) {
         this.scanAsAServiceModuleConfig = scanAsAServiceModuleConfig;
+        this.cancelDeciders = cancelDeciders;
     }
 
     @Override
@@ -33,5 +41,9 @@ public class ScanAsAServiceModule implements Module {
     @Override
     public List<AnalyticsCollector> getAnalyticsCollectors() {
         return null;
+    }
+
+    public void handleBeforeDownloadEvent(Request request, RepoPath repoPath) {
+        cancelDeciders.forEach(cancelDecider -> cancelDecider.handleBeforeDownloadEvent(repoPath));
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModule.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModule.java
@@ -1,0 +1,38 @@
+/*
+ * blackduck-artifactory-common
+ *
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
+ */
+package com.synopsys.integration.blackduck.artifactory.modules.scaas;
+
+import java.util.List;
+
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.blackduck.artifactory.modules.Module;
+import com.synopsys.integration.blackduck.artifactory.modules.ModuleConfig;
+import com.synopsys.integration.blackduck.artifactory.modules.analytics.collector.AnalyticsCollector;
+import com.synopsys.integration.log.IntLogger;
+import com.synopsys.integration.log.Slf4jIntLogger;
+
+public class ScanAsAServiceModule implements Module {
+    private final IntLogger logger = new Slf4jIntLogger(LoggerFactory.getLogger(this.getClass()));
+
+    private final ScanAsAServiceModuleConfig scanAsAServiceModuleConfig;
+
+    public ScanAsAServiceModule(ScanAsAServiceModuleConfig scanAsAServiceModuleConfig) {
+        this.scanAsAServiceModuleConfig = scanAsAServiceModuleConfig;
+    }
+
+    @Override
+    public ScanAsAServiceModuleConfig getModuleConfig() {
+        return scanAsAServiceModuleConfig;
+    }
+
+    @Override
+    public List<AnalyticsCollector> getAnalyticsCollectors() {
+        return null;
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModule.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModule.java
@@ -12,7 +12,6 @@ import java.util.List;
 import org.slf4j.LoggerFactory;
 
 import com.synopsys.integration.blackduck.artifactory.modules.Module;
-import com.synopsys.integration.blackduck.artifactory.modules.ModuleConfig;
 import com.synopsys.integration.blackduck.artifactory.modules.analytics.collector.AnalyticsCollector;
 import com.synopsys.integration.log.IntLogger;
 import com.synopsys.integration.log.Slf4jIntLogger;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
@@ -68,6 +68,10 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         return moduleConfig.build();
     }
 
+    public ScanAsAServiceBlockingStrategy getBlockingStrategy() {
+        return this.blockingStrategy;
+    }
+
     @Override
     public void validate(PropertyGroupReport propertyGroupReport) {
         if (isEnabled()) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
@@ -12,22 +12,97 @@
 
 package com.synopsys.integration.blackduck.artifactory.modules.scaas;
 
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.configuration.ConfigurationPropertyManager;
 import com.synopsys.integration.blackduck.artifactory.configuration.model.PropertyGroupReport;
 import com.synopsys.integration.blackduck.artifactory.modules.ModuleConfig;
 
 public class ScanAsAServiceModuleConfig extends ModuleConfig {
-    public ScanAsAServiceModuleConfig(Boolean enabled) {
-        super(ScanAsAServiceModule.class.getSimpleName(), enabled);
+    private static final Logger logger = LoggerFactory.getLogger(ScanAsAServiceModuleConfig.class);
+
+    private final ScanAsAServiceBlockingStrategy blockingStrategy;
+
+    private final List<String> repos;
+
+
+    protected ScanAsAServiceModuleConfig(Builder builder) {
+        super(ScanAsAServiceModule.class.getSimpleName(), builder.enabled);
+        this.blockingStrategy = builder.blockingStrategy;
+        this.repos = new ArrayList<>(builder.repos);
     }
 
-    public static ScanAsAServiceModuleConfig createFromProperties() {
-        return new ScanAsAServiceModuleConfig(
-                Boolean.TRUE
-        );
+    public static ScanAsAServiceModuleConfig createFromProperties(ConfigurationPropertyManager configurationPropertyManager, ArtifactoryPAPIService artifactoryPAPIService)
+            throws IOException {
+        Boolean enabled = configurationPropertyManager.getBooleanProperty(ScanAsAServiceModuleProperty.ENABLED);
+        ScanAsAServiceModuleConfig.Builder moduleConfig = ScanAsAServiceModuleConfig.Builder.newInstance(enabled);
+        logger.debug("blackDuckPlugin: ScanAsAService: property: {}; value: {}", ScanAsAServiceModuleProperty.ENABLED.getKey(), enabled);
+        if (Boolean.TRUE.equals(enabled)) {
+            // Only parse properties if the module is enabled
+            ScanAsAServiceBlockingStrategy blockingStrategy = null;
+            String blockingStrategyAsString = null;
+            try {
+                blockingStrategyAsString = configurationPropertyManager.getProperty(ScanAsAServiceModuleProperty.BLOCKING_STRATEGY);
+                blockingStrategy = ScanAsAServiceBlockingStrategy.valueOf(blockingStrategyAsString);
+            } catch (IllegalArgumentException e) {
+                logger.warn("blackDuckPlugin: ScanAsAService: Unknown value provided for {}: {}", ScanAsAServiceModuleProperty.BLOCKING_STRATEGY.getKey(),
+                        blockingStrategyAsString);
+            }
+            moduleConfig.withBlockingStrategy(blockingStrategy);
+            List<String> repos = configurationPropertyManager.getRepositoryKeysFromProperties(ScanAsAServiceModuleProperty.BLOCKING_REPOS, ScanAsAServiceModuleProperty.BLOCKING_REPOS_CSV_PATH)
+                    .stream()
+                    .filter(artifactoryPAPIService::isValidRepository)
+                    .collect(Collectors.toList());
+            if (!repos.isEmpty()) {
+                moduleConfig.withRepos(repos);
+            }
+        }
+
+        return moduleConfig.build();
     }
 
     @Override
     public void validate(PropertyGroupReport propertyGroupReport) {
+        if (isEnabled()) {
+            // Only generate property report if module is enabled
+            validateNotNull(propertyGroupReport, ScanAsAServiceModuleProperty.BLOCKING_STRATEGY, this.blockingStrategy);
+            validateList(propertyGroupReport, ScanAsAServiceModuleProperty.BLOCKING_REPOS, this.repos,
+                    String.format("No valid repositories specified. Please set the %s property with valid repositories", ScanAsAServiceModuleProperty.BLOCKING_REPOS.getKey()));
+        }
+    }
 
+    public static class Builder {
+        private Boolean enabled;
+        private ScanAsAServiceBlockingStrategy blockingStrategy;
+        private List<String> repos = new ArrayList<>();
+
+        private Builder(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public static Builder newInstance(Boolean enabled) {
+            return new Builder(enabled);
+        }
+
+        public Builder withBlockingStrategy(ScanAsAServiceBlockingStrategy blockingStrategy) {
+            this.blockingStrategy = blockingStrategy;
+            return this;
+        }
+
+        public Builder withRepos(List<String> repos) {
+            this.repos.addAll(repos);
+            return this;
+        }
+
+        public ScanAsAServiceModuleConfig build() {
+            return new ScanAsAServiceModuleConfig(this);
+        }
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
@@ -27,7 +27,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
 
     private final ScanAsAServiceBlockingStrategy blockingStrategy;
 
-    private final List<String> repos;
+    private final List<String> blockingRepos;
 
     private final String cutoffDateString;
 
@@ -37,7 +37,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
     protected ScanAsAServiceModuleConfig(Builder builder) {
         super(ScanAsAServiceModule.class.getSimpleName(), builder.enabled);
         this.blockingStrategy = builder.blockingStrategy;
-        this.repos = new ArrayList<>(builder.repos);
+        this.blockingRepos = new ArrayList<>(builder.blockingRepos);
         this.cutoffDateString = builder.cutoffDateString;
         this.dateTimeManager = builder.dateTimeManager;
     }
@@ -66,7 +66,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
                     .filter(artifactoryPAPIService::isValidRepository)
                     .collect(Collectors.toList());
             if (!repos.isEmpty()) {
-                moduleConfig.withRepos(repos);
+                moduleConfig.withBlockingRepos(repos);
             }
             String cutoffDateString;
             if ((cutoffDateString = configurationPropertyManager.getProperty(ScanAsAServiceModuleProperty.CUTOFF_DATE)) != null) {
@@ -79,6 +79,10 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
 
     public ScanAsAServiceBlockingStrategy getBlockingStrategy() {
         return this.blockingStrategy;
+    }
+
+    public List<String> getBlockingRepos() {
+        return this.blockingRepos;
     }
 
     public Optional<String> getCutoffDateString() {
@@ -94,7 +98,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         if (isEnabled()) {
             // Only generate property report if module is enabled
             validateNotNull(propertyGroupReport, ScanAsAServiceModuleProperty.BLOCKING_STRATEGY, this.blockingStrategy);
-            validateList(propertyGroupReport, ScanAsAServiceModuleProperty.BLOCKING_REPOS, this.repos,
+            validateList(propertyGroupReport, ScanAsAServiceModuleProperty.BLOCKING_REPOS, this.blockingRepos,
                     String.format("No valid repositories specified. Please set the %s property with valid repositories", ScanAsAServiceModuleProperty.BLOCKING_REPOS.getKey()));
             getCutoffDateString().ifPresentOrElse(cutoffDateString ->
                 validateDate(propertyGroupReport, ScanAsAServiceModuleProperty.CUTOFF_DATE, cutoffDateString, dateTimeManager),
@@ -105,7 +109,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
     public static class Builder {
         private Boolean enabled;
         private ScanAsAServiceBlockingStrategy blockingStrategy;
-        private List<String> repos = new ArrayList<>();
+        private List<String> blockingRepos = new ArrayList<>();
         private String cutoffDateString;
 
         private DateTimeManager dateTimeManager;
@@ -124,8 +128,8 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
             return this;
         }
 
-        public Builder withRepos(List<String> repos) {
-            this.repos.addAll(repos);
+        public Builder withBlockingRepos(List<String> repos) {
+            this.blockingRepos.addAll(repos);
             return this;
         }
 

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2022 Synopsys Inc.
+ * http://www.synopsys.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Synopsys ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Synopsys.
+ */
+
+package com.synopsys.integration.blackduck.artifactory.modules.scaas;
+
+import com.synopsys.integration.blackduck.artifactory.configuration.model.PropertyGroupReport;
+import com.synopsys.integration.blackduck.artifactory.modules.ModuleConfig;
+
+public class ScanAsAServiceModuleConfig extends ModuleConfig {
+    public ScanAsAServiceModuleConfig(Boolean enabled) {
+        super(ScanAsAServiceModule.class.getSimpleName(), enabled);
+    }
+
+    public static ScanAsAServiceModuleConfig createFromProperties() {
+        return new ScanAsAServiceModuleConfig(
+                Boolean.TRUE
+        );
+    }
+
+    @Override
+    public void validate(PropertyGroupReport propertyGroupReport) {
+
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
@@ -1,15 +1,10 @@
 /*
- * Copyright (C) 2022 Synopsys Inc.
- * http://www.synopsys.com/
- * All rights reserved.
+ * blackduck-artifactory-common
  *
- * This software is the confidential and proprietary information of
- * Synopsys ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Synopsys.
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-
 package com.synopsys.integration.blackduck.artifactory.modules.scaas;
 
 import java.io.IOException;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleConfig.java
@@ -94,7 +94,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
     }
 
     @Override
-    public void validate(PropertyGroupReport propertyGroupReport) {
+    public void validate(PropertyGroupReport propertyGroupReport, List<String> enabledModules) {
         if (isEnabled()) {
             // Only generate property report if module is enabled
             validateNotNull(propertyGroupReport, ScanAsAServiceModuleProperty.BLOCKING_STRATEGY, this.blockingStrategy);

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
@@ -14,6 +14,7 @@ public enum ScanAsAServiceModuleProperty implements ConfigurationProperty {
     BLOCKING_STRATEGY("blocking.strategy"),
     BLOCKING_REPOS("blocking.repos"),
     BLOCKING_REPOS_CSV_PATH("blocking.repos.csv.path"),
+    CUTOFF_DATE("cutoff.date"),
     ;
 
     private static final String SCAN_AS_A_SERVICE_MODULE_PROPERTY_PREFIX = "blackduck.artifactory.scaas.";

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
@@ -17,7 +17,7 @@ public enum ScanAsAServiceModuleProperty implements ConfigurationProperty {
     CUTOFF_DATE("cutoff.date"),
     ;
 
-    private static final String SCAN_AS_A_SERVICE_MODULE_PROPERTY_PREFIX = "blackduck.artifactory.scaas.";
+    private static final String SCAN_AS_A_SERVICE_MODULE_PROPERTY_PREFIX = "blackduck.artifactory.scaaas.";
     private final String key;
 
     ScanAsAServiceModuleProperty(String key) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2022 Synopsys Inc.
+ * http://www.synopsys.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Synopsys ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Synopsys.
+ */
+
+package com.synopsys.integration.blackduck.artifactory.modules.scaas;
+
+import com.synopsys.integration.blackduck.artifactory.configuration.ConfigurationProperty;
+
+public enum ScanAsAServiceModuleProperty implements ConfigurationProperty {
+    ENABLED("enabled"),
+    BLOCKING_STRATEGY("blocking.strategy"),
+    BLOCKING_REPOS("blocking.repos"),
+    BLOCKING_REPOS_CSV_PATH("blocking.repos.csv.path"),
+    ;
+
+    private static final String SCAN_AS_A_SERVICE_MODULE_PROPERTY_PREFIX = "blackduck.artifactory.scaas.";
+    private final String key;
+
+    ScanAsAServiceModuleProperty(String key) {
+        this.key = SCAN_AS_A_SERVICE_MODULE_PROPERTY_PREFIX + key;
+    }
+
+    @Override
+    public String getKey() {
+        return key;
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceModuleProperty.java
@@ -1,15 +1,10 @@
 /*
- * Copyright (C) 2022 Synopsys Inc.
- * http://www.synopsys.com/
- * All rights reserved.
+ * blackduck-artifactory-common
  *
- * This software is the confidential and proprietary information of
- * Synopsys ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Synopsys.
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-
 package com.synopsys.integration.blackduck.artifactory.modules.scaas;
 
 import com.synopsys.integration.blackduck.artifactory.configuration.ConfigurationProperty;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServicePropertyService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServicePropertyService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2022 Synopsys Inc.
+ * http://www.synopsys.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Synopsys ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Synopsys.
+ */
+
+package com.synopsys.integration.blackduck.artifactory.modules.scaas;
+
+import java.util.Optional;
+
+import org.artifactory.repo.RepoPath;
+
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPropertyService;
+import com.synopsys.integration.blackduck.artifactory.BlackDuckArtifactoryProperty;
+import com.synopsys.integration.blackduck.artifactory.DateTimeManager;
+
+public class ScanAsAServicePropertyService extends ArtifactoryPropertyService {
+    public ScanAsAServicePropertyService(ArtifactoryPAPIService artifactoryPAPIService,
+            DateTimeManager dateTimeManager) {
+        super(artifactoryPAPIService, dateTimeManager);
+    }
+
+    public Optional<ScanAsAServiceScanStatus> getScanStatusProperty(RepoPath repoPath) {
+        return getProperty(repoPath, BlackDuckArtifactoryProperty.SCAN_STATUS)
+                .map(ScanAsAServiceScanStatus::getValue);
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServicePropertyService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServicePropertyService.java
@@ -24,12 +24,12 @@ public class ScanAsAServicePropertyService extends ArtifactoryPropertyService {
     }
 
     public Optional<ScanAsAServiceScanStatus> getScanStatusProperty(RepoPath repoPath) {
-        return getProperty(repoPath, BlackDuckArtifactoryProperty.SCAN_STATUS)
+        return getProperty(repoPath, BlackDuckArtifactoryProperty.SCAAAS_SCAN_STATUS)
                 .map(ScanAsAServiceScanStatus::getValue);
     }
 
-    public Optional<ProjectVersionComponentPolicyStatusType> getOverallPolicyStatus(RepoPath repoPath) {
-        return getProperty(repoPath, BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS)
+    public Optional<ProjectVersionComponentPolicyStatusType> getPolicyStatus(RepoPath repoPath) {
+        return getProperty(repoPath, BlackDuckArtifactoryProperty.SCAAAS_POLICY_STATUS)
                 .map(ProjectVersionComponentPolicyStatusType::valueOf);
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServicePropertyService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServicePropertyService.java
@@ -1,21 +1,17 @@
 /*
- * Copyright (C) 2022 Synopsys Inc.
- * http://www.synopsys.com/
- * All rights reserved.
+ * blackduck-artifactory-common
  *
- * This software is the confidential and proprietary information of
- * Synopsys ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Synopsys.
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-
 package com.synopsys.integration.blackduck.artifactory.modules.scaas;
 
 import java.util.Optional;
 
 import org.artifactory.repo.RepoPath;
 
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
 import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
 import com.synopsys.integration.blackduck.artifactory.ArtifactoryPropertyService;
 import com.synopsys.integration.blackduck.artifactory.BlackDuckArtifactoryProperty;
@@ -30,5 +26,10 @@ public class ScanAsAServicePropertyService extends ArtifactoryPropertyService {
     public Optional<ScanAsAServiceScanStatus> getScanStatusProperty(RepoPath repoPath) {
         return getProperty(repoPath, BlackDuckArtifactoryProperty.SCAN_STATUS)
                 .map(ScanAsAServiceScanStatus::getValue);
+    }
+
+    public Optional<ProjectVersionComponentPolicyStatusType> getOverallPolicyStatus(RepoPath repoPath) {
+        return getProperty(repoPath, BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS)
+                .map(ProjectVersionComponentPolicyStatusType::valueOf);
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceScanStatus.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceScanStatus.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2022 Synopsys Inc.
+ * http://www.synopsys.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Synopsys ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Synopsys.
+ */
+
+package com.synopsys.integration.blackduck.artifactory.modules.scaas;
+
+import javax.annotation.Nullable;
+
+public enum ScanAsAServiceScanStatus {
+    SCAN_IN_PROGRESS("Scanning currently in progress."),
+    SUCCESS_NO_POLICY_VIOLATION(null),
+    SUCCESS_POLICY_VIOLATION("Scan successfully complete, but policy violations were detected."),
+    FAILED("Scan failed"),
+    UNKNOWN(""),
+    ;
+
+    private final String message;
+
+    ScanAsAServiceScanStatus(@Nullable String message) {
+        this.message = message;
+    }
+
+    @Nullable
+    public String getMessage() {
+        return message;
+    }
+
+    public static ScanAsAServiceScanStatus getValue(String value) {
+        for(ScanAsAServiceScanStatus val : ScanAsAServiceScanStatus.values()) {
+            if (val.name().equals(value))
+                return val;
+        }
+        return ScanAsAServiceScanStatus.UNKNOWN;
+    }
+}

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceScanStatus.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaas/ScanAsAServiceScanStatus.java
@@ -1,25 +1,18 @@
 /*
- * Copyright (C) 2022 Synopsys Inc.
- * http://www.synopsys.com/
- * All rights reserved.
+ * blackduck-artifactory-common
  *
- * This software is the confidential and proprietary information of
- * Synopsys ("Confidential Information"). You shall not
- * disclose such Confidential Information and shall use it only in
- * accordance with the terms of the license agreement you entered into
- * with Synopsys.
+ * Copyright (c) 2022 Synopsys, Inc.
+ *
+ * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
-
 package com.synopsys.integration.blackduck.artifactory.modules.scaas;
 
 import javax.annotation.Nullable;
 
 public enum ScanAsAServiceScanStatus {
-    SCAN_IN_PROGRESS("Scanning currently in progress."),
-    SUCCESS_NO_POLICY_VIOLATION(null),
-    SUCCESS_POLICY_VIOLATION("Scan successfully complete, but policy violations were detected."),
+    PROCESSING("Artifact identified and Scanner notified."),
+    SUCCESS("Scan successful"),
     FAILED("Scan failed"),
-    UNKNOWN(""),
     ;
 
     private final String message;
@@ -38,6 +31,6 @@ public enum ScanAsAServiceScanStatus {
             if (val.name().equals(value))
                 return val;
         }
-        return ScanAsAServiceScanStatus.UNKNOWN;
+        throw new IllegalArgumentException(String.format("Unable to find suitable ScanAsAServiceScanStatus; Value: %s", value));
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/ScanModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scan/ScanModuleConfig.java
@@ -155,7 +155,7 @@ public class ScanModuleConfig extends ModuleConfig {
     }
 
     @Override
-    public void validate(PropertyGroupReport propertyGroupReport) {
+    public void validate(PropertyGroupReport propertyGroupReport, List<String> enabeledModules) {
         validateCronExpression(propertyGroupReport, ScanModuleProperty.CRON, cron);
         validateDate(propertyGroupReport, ScanModuleProperty.CUTOFF_DATE, artifactCutoffDate, dateTimeManager);
         validateBoolean(propertyGroupReport, ScanModuleProperty.DRY_RUN, dryRun);

--- a/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright (C) 2022 Synopsys Inc.
+ * http://www.synopsys.com/
+ * All rights reserved.
+ *
+ * This software is the confidential and proprietary information of
+ * Synopsys ("Confidential Information"). You shall not
+ * disclose such Confidential Information and shall use it only in
+ * accordance with the terms of the license agreement you entered into
+ * with Synopsys.
+ */
+
+package cancel;
+
+import java.util.Optional;
+import java.util.stream.Stream;
+
+import org.artifactory.fs.ItemInfo;
+import org.artifactory.repo.RepoPath;
+import org.jetbrains.annotations.NotNull;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.PluginRepoPathFactory;
+import com.synopsys.integration.blackduck.artifactory.modules.cancel.CancelDecision;
+import com.synopsys.integration.blackduck.artifactory.modules.cancel.ScanAsAServiceCancelDecider;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceBlockingStrategy;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceModuleConfig;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServicePropertyService;
+import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus;
+
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceBlockingStrategy.BLOCK_ALL;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceBlockingStrategy.BLOCK_NONE;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.FAILED;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.SUCCESS_NO_POLICY_VIOLATION;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.SUCCESS_POLICY_VIOLATION;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.SCAN_IN_PROGRESS;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.UNKNOWN;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+public class ScanAsAServiceCancelDeciderTest {
+    private static String TEST_REPO_PATH = "test-repo";
+    private static String TEST_ARTIFACT_NAME = "test-artifact.jar";
+
+    private static Stream<Arguments> providerValuesForGetCancelDecision() {
+        // Description, ScanAsAServiceBlockinStrategy, ScanAsAServiceScanStatus, CancelDecision, CancelDecisionText
+        return Stream.of(
+                arguments("No Blocking; Scan Success with Policy Violations", BLOCK_NONE, SUCCESS_NO_POLICY_VIOLATION, CancelDecision.NO_CANCELLATION()),
+                arguments("No Blocking; Scan Success with No Policy Violations", BLOCK_NONE, SUCCESS_POLICY_VIOLATION, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", SUCCESS_POLICY_VIOLATION.getMessage(), artifactPath))),
+                arguments("No Blocking; Scan in progress", BLOCK_NONE, SCAN_IN_PROGRESS, CancelDecision.NO_CANCELLATION()),
+                arguments("No Blocking; Scan Failed", BLOCK_NONE, FAILED, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath))),
+                arguments("No Blocking; Unknown Scan Status", BLOCK_NONE, UNKNOWN, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", UNKNOWN, artifactPath))),
+                arguments("Blocking; Scan Success with Policy Violations", BLOCK_ALL, SUCCESS_NO_POLICY_VIOLATION, CancelDecision.NO_CANCELLATION()),
+                arguments("Blocking; Scan Success with No Policy Violations", BLOCK_ALL, SUCCESS_POLICY_VIOLATION, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", SUCCESS_POLICY_VIOLATION.getMessage(), artifactPath))),
+                arguments("Blocking; Scan in progress", BLOCK_ALL, SCAN_IN_PROGRESS, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", SCAN_IN_PROGRESS.getMessage(), artifactPath))),
+                arguments("Blocking; Scan Failed", BLOCK_ALL, FAILED, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath)))
+        );
+    }
+
+    @Mock
+    private ArtifactoryPAPIService artifactoryPAPIService;
+
+    @Mock
+    private ScanAsAServiceModuleConfig scanAsAServiceModuleConfig;
+
+    @Mock
+    private ScanAsAServicePropertyService scanAsAServicePropertyService;
+
+    private static PluginRepoPathFactory pluginRepoPathFactory;
+
+    private static RepoPath repoPath;
+
+    private static RepoPath artifactPath;
+
+    private ScanAsAServiceCancelDecider sut;
+
+    @BeforeAll
+    public static void beforeAll() {
+        pluginRepoPathFactory = new PluginRepoPathFactory(false);
+        repoPath = pluginRepoPathFactory.create(TEST_REPO_PATH);
+        artifactPath = pluginRepoPathFactory.create(repoPath.getRepoKey(), TEST_ARTIFACT_NAME);
+    }
+
+    public ScanAsAServiceCancelDeciderTest() {
+        initMocks(this);
+        sut = new ScanAsAServiceCancelDecider(scanAsAServiceModuleConfig, scanAsAServicePropertyService, artifactoryPAPIService);
+    }
+
+    @ParameterizedTest(name = "{index}: {0}")
+    @MethodSource("providerValuesForGetCancelDecision")
+    public void testGetCancelDecision(String description, ScanAsAServiceBlockingStrategy blockingStrategy, ScanAsAServiceScanStatus scanStatus, CancelDecision expectedResult) {
+        Mockito.when(scanAsAServiceModuleConfig.getBlockingStrategy()).thenReturn(blockingStrategy);
+        Mockito.when(scanAsAServicePropertyService.getScanStatusProperty(artifactPath)).thenReturn(Optional.ofNullable(scanStatus));
+        Mockito.when(artifactoryPAPIService.getItemInfo(artifactPath)).thenReturn(new ItemInfo() {
+            @Override public long getId() {
+                return 0;
+            }
+
+            @Override public RepoPath getRepoPath() {
+                return null;
+            }
+
+            @Override public boolean isFolder() {
+                return false;
+            }
+
+            @Override public String getName() {
+                return null;
+            }
+
+            @Override public String getRepoKey() {
+                return null;
+            }
+
+            @Override public String getRelPath() {
+                return null;
+            }
+
+            @Override public long getCreated() {
+                return 0;
+            }
+
+            @Override public long getLastModified() {
+                return 0;
+            }
+
+            @Override public String getModifiedBy() {
+                return null;
+            }
+
+            @Override public String getCreatedBy() {
+                return null;
+            }
+
+            @Override public long getLastUpdated() {
+                return 0;
+            }
+
+            @Override public boolean isIdentical(ItemInfo info) {
+                return false;
+            }
+
+            @Override public int compareTo(@NotNull ItemInfo o) {
+                return 0;
+            }
+        });
+        CancelDecision actualResult = sut.getCancelDecision(artifactPath);
+        assertEquals(expectedResult, actualResult);
+    }
+}

--- a/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 
+import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
 import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
 import com.synopsys.integration.blackduck.artifactory.PluginRepoPathFactory;
 import com.synopsys.integration.blackduck.artifactory.modules.cancel.CancelDecision;
@@ -34,13 +35,13 @@ import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServi
 import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServicePropertyService;
 import com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus;
 
+import static com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType.IN_VIOLATION;
+import static com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType.NOT_IN_VIOLATION;
 import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceBlockingStrategy.BLOCK_ALL;
 import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceBlockingStrategy.BLOCK_NONE;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.SUCCESS;
+import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.PROCESSING;
 import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.FAILED;
-import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.SUCCESS_NO_POLICY_VIOLATION;
-import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.SUCCESS_POLICY_VIOLATION;
-import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.SCAN_IN_PROGRESS;
-import static com.synopsys.integration.blackduck.artifactory.modules.scaas.ScanAsAServiceScanStatus.UNKNOWN;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.params.provider.Arguments.arguments;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -50,17 +51,16 @@ public class ScanAsAServiceCancelDeciderTest {
     private static String TEST_ARTIFACT_NAME = "test-artifact.jar";
 
     private static Stream<Arguments> providerValuesForGetCancelDecision() {
-        // Description, ScanAsAServiceBlockinStrategy, ScanAsAServiceScanStatus, CancelDecision, CancelDecisionText
+        // Description, ScanAsAServiceBlockinStrategy, ScanAsAServiceScanStatus, ProjectVersionComponentPolicyStatusType, CancelDecision, CancelDecisionText
         return Stream.of(
-                arguments("No Blocking; Scan Success with Policy Violations", BLOCK_NONE, SUCCESS_NO_POLICY_VIOLATION, CancelDecision.NO_CANCELLATION()),
-                arguments("No Blocking; Scan Success with No Policy Violations", BLOCK_NONE, SUCCESS_POLICY_VIOLATION, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", SUCCESS_POLICY_VIOLATION.getMessage(), artifactPath))),
-                arguments("No Blocking; Scan in progress", BLOCK_NONE, SCAN_IN_PROGRESS, CancelDecision.NO_CANCELLATION()),
-                arguments("No Blocking; Scan Failed", BLOCK_NONE, FAILED, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath))),
-                arguments("No Blocking; Unknown Scan Status", BLOCK_NONE, UNKNOWN, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", UNKNOWN, artifactPath))),
-                arguments("Blocking; Scan Success with Policy Violations", BLOCK_ALL, SUCCESS_NO_POLICY_VIOLATION, CancelDecision.NO_CANCELLATION()),
-                arguments("Blocking; Scan Success with No Policy Violations", BLOCK_ALL, SUCCESS_POLICY_VIOLATION, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", SUCCESS_POLICY_VIOLATION.getMessage(), artifactPath))),
-                arguments("Blocking; Scan in progress", BLOCK_ALL, SCAN_IN_PROGRESS, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", SCAN_IN_PROGRESS.getMessage(), artifactPath))),
-                arguments("Blocking; Scan Failed", BLOCK_ALL, FAILED, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath)))
+                arguments("No Blocking; Scan Success with Policy Violations", BLOCK_NONE, SUCCESS, IN_VIOLATION, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath))),
+                arguments("No Blocking; Scan Success with No Policy Violations", BLOCK_NONE, SUCCESS, NOT_IN_VIOLATION, CancelDecision.NO_CANCELLATION()),
+                arguments("No Blocking; Scan in progress", BLOCK_NONE, PROCESSING, null, CancelDecision.NO_CANCELLATION()),
+                arguments("No Blocking; Scan Failed", BLOCK_NONE, FAILED, null, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath))),
+                arguments("Blocking; Scan Success with No Policy Violations", BLOCK_ALL, SUCCESS, NOT_IN_VIOLATION, CancelDecision.NO_CANCELLATION()),
+                arguments("Blocking; Scan Success with Policy Violations", BLOCK_ALL, SUCCESS, IN_VIOLATION, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath))),
+                arguments("Blocking; Scan in progress", BLOCK_ALL, PROCESSING, null, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", PROCESSING.getMessage(), artifactPath))),
+                arguments("Blocking; Scan Failed", BLOCK_ALL, FAILED, null, CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath)))
         );
     }
 
@@ -95,9 +95,10 @@ public class ScanAsAServiceCancelDeciderTest {
 
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("providerValuesForGetCancelDecision")
-    public void testGetCancelDecision(String description, ScanAsAServiceBlockingStrategy blockingStrategy, ScanAsAServiceScanStatus scanStatus, CancelDecision expectedResult) {
+    public void testGetCancelDecision(String description, ScanAsAServiceBlockingStrategy blockingStrategy, ScanAsAServiceScanStatus scanStatus, ProjectVersionComponentPolicyStatusType policyViolationStatus, CancelDecision expectedResult) {
         Mockito.when(scanAsAServiceModuleConfig.getBlockingStrategy()).thenReturn(blockingStrategy);
         Mockito.when(scanAsAServicePropertyService.getScanStatusProperty(artifactPath)).thenReturn(Optional.ofNullable(scanStatus));
+        Mockito.when(scanAsAServicePropertyService.getOverallPolicyStatus(artifactPath)).thenReturn(Optional.ofNullable(policyViolationStatus));
         Mockito.when(artifactoryPAPIService.getItemInfo(artifactPath)).thenReturn(new ItemInfo() {
             @Override public long getId() {
                 return 0;

--- a/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
@@ -15,6 +15,7 @@ package cancel;
 import java.time.Instant;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -52,14 +53,18 @@ import static org.mockito.MockitoAnnotations.initMocks;
 
 public class ScanAsAServiceCancelDeciderTest {
     private static String TEST_REPO_PATH = "test-repo";
+
+    private static String TEST_OUTSIDE_REPO_PATH = "test-outside-repo";
+
     private static String TEST_ARTIFACT_NAME = "test-artifact.jar";
 
     private static String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
     private static Stream<Arguments> providerValuesForGetCancelDecision() {
-        // Description, ScanAsAServiceBlockinStrategy, ScanAsAServiceScanStatus, ProjectVersionComponentPolicyStatusType, String(lastUpdated), String(cutoffDate), CancelDecision
+        // Description, ArtifactRepoPath, ScanAsAServiceBlockinStrategy, ScanAsAServiceScanStatus, ProjectVersionComponentPolicyStatusType, String(lastUpdated), String(cutoffDate), CancelDecision
         return Stream.of(
                 arguments("No Blocking; Scan Success with Policy Violations",
+                        artifactPath,
                         BLOCK_NONE,
                         SUCCESS,
                         IN_VIOLATION,
@@ -67,6 +72,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath))),
                 arguments("No Blocking; Scan Success with No Policy Violations",
+                        artifactPath,
                         BLOCK_NONE,
                         SUCCESS,
                         NOT_IN_VIOLATION,
@@ -74,6 +80,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.NO_CANCELLATION()),
                 arguments("No Blocking; Scan in progress",
+                        artifactPath,
                         BLOCK_NONE,
                         PROCESSING,
                         null,
@@ -81,6 +88,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.NO_CANCELLATION()),
                 arguments("No Blocking; Scan Failed",
+                        artifactPath,
                         BLOCK_NONE,
                         FAILED,
                         null,
@@ -88,6 +96,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath))),
                 arguments("Blocking; Scan Success with No Policy Violations",
+                        artifactPath,
                         BLOCK_ALL,
                         SUCCESS,
                         NOT_IN_VIOLATION,
@@ -95,6 +104,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.NO_CANCELLATION()),
                 arguments("Blocking; Scan Success with Policy Violations",
+                        artifactPath,
                         BLOCK_ALL,
                         SUCCESS,
                         IN_VIOLATION,
@@ -102,6 +112,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath))),
                 arguments("Blocking; Scan in progress",
+                        artifactPath,
                         BLOCK_ALL,
                         PROCESSING,
                         null,
@@ -109,6 +120,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", PROCESSING.getMessage(), artifactPath))),
                 arguments("Blocking; Scan Failed",
+                        artifactPath,
                         BLOCK_ALL,
                         FAILED,
                         null,
@@ -116,6 +128,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath))),
                 arguments("No Blocking; Last updated prior to cutoff",
+                        artifactPath,
                         BLOCK_ALL,
                         SUCCESS,
                         IN_VIOLATION, // The combination of these will cause blocking if the cutoff logic fails
@@ -123,6 +136,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.NO_CANCELLATION()),
                 arguments("No Blocking; Last updated same as cutoff",
+                        artifactPath,
                         BLOCK_ALL,
                         SUCCESS,
                         IN_VIOLATION, // The combination of these will cause blocking if the cutoff logic fails
@@ -130,12 +144,21 @@ public class ScanAsAServiceCancelDeciderTest {
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         CancelDecision.NO_CANCELLATION()),
                 arguments("Blocking; In violation; Provide null cutoff time",
+                        artifactPath,
                         BLOCK_ALL,
                         SUCCESS,
                         IN_VIOLATION,
                         Instant.now().atOffset(ZoneOffset.UTC).minusYears(3).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
                         null,
-                        CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath)))
+                        CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath))),
+                arguments("No Blocking; Repo path not in blocking repos",
+                        outsideArtifactPath,
+                        BLOCK_ALL,
+                        SUCCESS,
+                        IN_VIOLATION, // The combination of these will cause blocking if the blocking repos check fails
+                        Instant.now().atOffset(ZoneOffset.UTC).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
+                        Instant.now().atOffset(ZoneOffset.UTC).minusYears(1).toLocalDate().atStartOfDay().format(DateTimeFormatter.ofPattern(DATETIME_PATTERN)),
+                        CancelDecision.NO_CANCELLATION())
         );
     }
 
@@ -150,9 +173,9 @@ public class ScanAsAServiceCancelDeciderTest {
 
     private static PluginRepoPathFactory pluginRepoPathFactory;
 
-    private static RepoPath repoPath;
-
     private static RepoPath artifactPath;
+
+    private static RepoPath outsideArtifactPath;
 
     private static DateTimeManager dateTimeManager;
 
@@ -161,8 +184,10 @@ public class ScanAsAServiceCancelDeciderTest {
     @BeforeAll
     public static void beforeAll() {
         pluginRepoPathFactory = new PluginRepoPathFactory(false);
-        repoPath = pluginRepoPathFactory.create(TEST_REPO_PATH);
+        RepoPath repoPath = pluginRepoPathFactory.create(TEST_REPO_PATH);
         artifactPath = pluginRepoPathFactory.create(repoPath.getRepoKey(), TEST_ARTIFACT_NAME);
+        RepoPath outsideRepoPath = pluginRepoPathFactory.create(TEST_OUTSIDE_REPO_PATH);
+        outsideArtifactPath = pluginRepoPathFactory.create(outsideRepoPath.getRepoKey(), TEST_ARTIFACT_NAME);
         dateTimeManager = new DateTimeManager(DATETIME_PATTERN);
     }
 
@@ -174,6 +199,7 @@ public class ScanAsAServiceCancelDeciderTest {
     @ParameterizedTest(name = "{index}: {0}")
     @MethodSource("providerValuesForGetCancelDecision")
     public void testGetCancelDecision(String description,
+            RepoPath repoPath,
             ScanAsAServiceBlockingStrategy blockingStrategy,
             ScanAsAServiceScanStatus scanStatus,
             ProjectVersionComponentPolicyStatusType policyViolationStatus,
@@ -181,17 +207,18 @@ public class ScanAsAServiceCancelDeciderTest {
             String cutoffDate,
             CancelDecision expectedResult) {
         Mockito.when(scanAsAServiceModuleConfig.getBlockingStrategy()).thenReturn(blockingStrategy);
+        Mockito.when(scanAsAServiceModuleConfig.getBlockingRepos()).thenReturn(List.of(TEST_REPO_PATH));
         Mockito.when(scanAsAServiceModuleConfig.getDateTimeManager()).thenReturn(dateTimeManager);
         Mockito.when(scanAsAServiceModuleConfig.getCutoffDateString()).thenReturn(Optional.ofNullable(cutoffDate));
-        Mockito.when(scanAsAServicePropertyService.getScanStatusProperty(artifactPath)).thenReturn(Optional.ofNullable(scanStatus));
-        Mockito.when(scanAsAServicePropertyService.getPolicyStatus(artifactPath)).thenReturn(Optional.ofNullable(policyViolationStatus));
-        Mockito.when(artifactoryPAPIService.getItemInfo(artifactPath)).thenReturn(new ItemInfo() {
+        Mockito.when(scanAsAServicePropertyService.getScanStatusProperty(repoPath)).thenReturn(Optional.ofNullable(scanStatus));
+        Mockito.when(scanAsAServicePropertyService.getPolicyStatus(repoPath)).thenReturn(Optional.ofNullable(policyViolationStatus));
+        Mockito.when(artifactoryPAPIService.getItemInfo(repoPath)).thenReturn(new ItemInfo() {
             @Override public long getId() {
                 return 0;
             }
 
             @Override public RepoPath getRepoPath() {
-                return null;
+                return repoPath;
             }
 
             @Override public boolean isFolder() {
@@ -203,7 +230,7 @@ public class ScanAsAServiceCancelDeciderTest {
             }
 
             @Override public String getRepoKey() {
-                return null;
+                return repoPath.getRepoKey();
             }
 
             @Override public String getRelPath() {
@@ -238,7 +265,7 @@ public class ScanAsAServiceCancelDeciderTest {
                 return 0;
             }
         });
-        CancelDecision actualResult = sut.getCancelDecision(artifactPath);
+        CancelDecision actualResult = sut.getCancelDecision(repoPath);
         assertEquals(expectedResult, actualResult);
     }
 }

--- a/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
@@ -98,7 +98,7 @@ public class ScanAsAServiceCancelDeciderTest {
     public void testGetCancelDecision(String description, ScanAsAServiceBlockingStrategy blockingStrategy, ScanAsAServiceScanStatus scanStatus, ProjectVersionComponentPolicyStatusType policyViolationStatus, CancelDecision expectedResult) {
         Mockito.when(scanAsAServiceModuleConfig.getBlockingStrategy()).thenReturn(blockingStrategy);
         Mockito.when(scanAsAServicePropertyService.getScanStatusProperty(artifactPath)).thenReturn(Optional.ofNullable(scanStatus));
-        Mockito.when(scanAsAServicePropertyService.getOverallPolicyStatus(artifactPath)).thenReturn(Optional.ofNullable(policyViolationStatus));
+        Mockito.when(scanAsAServicePropertyService.getPolicyStatus(artifactPath)).thenReturn(Optional.ofNullable(policyViolationStatus));
         Mockito.when(artifactoryPAPIService.getItemInfo(artifactPath)).thenReturn(new ItemInfo() {
             @Override public long getId() {
                 return 0;

--- a/build.gradle
+++ b/build.gradle
@@ -117,6 +117,7 @@ build.finalizedBy createFinalZip
 configure(subprojects) { project ->
     group = 'com.synopsys.integration'
     version = parentVersion
+    sourceCompatibility = 11
     dependencies {
         ext.artifactoryMinimumVersion = artifactoryMinimumVersion
         ext.blackDuckCommonVersion = blackDuckCommonVersion

--- a/build.properties
+++ b/build.properties
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2022 Synopsys Inc.
+# http://www.synopsys.com/
+# All rights reserved.
+#
+# This software is the confidential and proprietary information of
+# Synopsys ("Confidential Information"). You shall not
+# disclose such Confidential Information and shall use it only in
+# accordance with the terms of the license agreement you entered into
+# with Synopsys.
+#
+
+javaVersion=11

--- a/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
+++ b/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
@@ -1,7 +1,7 @@
 /*
  * blackduck-artifactory
  *
- * Copyright (c) 2021 Synopsys, Inc.
+ * Copyright (c) 2022 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */
@@ -421,7 +421,8 @@ private void initialize(final TriggerType triggerType) {
     final File etcDirectory = ctx.artifactoryHome.etcDir
     final File homeDirectory = ctx.artifactoryHome.homeDir
     final File pluginsDirectory = ctx.artifactoryHome.pluginsDir
-    final String thirdPartyVersion = ctx?.versionProvider?.running?.versionName?.toString()
+    // Used to be 'versionProvider.running', but that is no longer available, 'originalHomeVersion' is the closest substitute
+    final String thirdPartyVersion = ctx?.versionProvider?.originalHomeVersion?.versionName?.toString()
     final DirectoryConfig pluginConfig = DirectoryConfig.createDefault(homeDirectory, etcDirectory, pluginsDirectory, thirdPartyVersion, propertiesFilePathOverride)
 
     pluginService = new PluginService(pluginConfig, repositories, searches)

--- a/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
+++ b/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
@@ -412,6 +412,7 @@ download {
     beforeDownload { Request request, RepoPath repoPath ->
         pluginAPI.handleBeforeDownloadEventInspection(TriggerType.BEFORE_DOWNLOAD, repoPath)
         pluginAPI.handleBeforeDownloadEventScan(TriggerType.BEFORE_DOWNLOAD, repoPath)
+        pluginAPI.handleBeforeDownloadEventScanAsAService(TriggerType.BEFORE_DOWNLOAD, request, repoPath)
     }
 }
 

--- a/src/main/resources/blackDuckPlugin.properties
+++ b/src/main/resources/blackDuckPlugin.properties
@@ -69,5 +69,12 @@ blackduck.artifactory.inspect.policy.repos=
 blackduck.artifactory.inspect.policy.repos.csv.path=
 blackduck.artifactory.inspect.policy.severity.types=BLOCKER,CRITICAL,MAJOR,MINOR,TRIVIAL,UNSPECIFIED
 #
+# Scan-as-a-Service (scaas)
+# If Scan-as-a-Service is enabled, Scanner and Inspector *should* be disabled
+blackduck.artifactory.scaas.enabled=false
+blackduck.artifactory.scaas.blocking.strategy=BLOCK_NONE
+blackduck.artifactory.scaas.blocking.repos=ext-release-local,libs-release
+blackduck.artifactory.scaas.blocking.repos.csv.path=
+#
 # Analytics
 blackduck.artifactory.analytics.enabled=true

--- a/src/main/resources/blackDuckPlugin.properties
+++ b/src/main/resources/blackDuckPlugin.properties
@@ -75,6 +75,10 @@ blackduck.artifactory.scaas.enabled=false
 blackduck.artifactory.scaas.blocking.strategy=BLOCK_NONE
 blackduck.artifactory.scaas.blocking.repos=ext-release-local,libs-release
 blackduck.artifactory.scaas.blocking.repos.csv.path=
+# Download of items prior to this date will be ALLOWED regardless of the
+# value of blackduck.artifactory.scaas.blocking.strategy
+# This date MUST comply with the format in blackduck.date.time.pattern
+blackduck.artifactory.scaas.cutoff.date=
 #
 # Analytics
 blackduck.artifactory.analytics.enabled=true

--- a/src/main/resources/blackDuckPlugin.properties
+++ b/src/main/resources/blackDuckPlugin.properties
@@ -69,14 +69,14 @@ blackduck.artifactory.inspect.policy.repos=
 blackduck.artifactory.inspect.policy.repos.csv.path=
 blackduck.artifactory.inspect.policy.severity.types=BLOCKER,CRITICAL,MAJOR,MINOR,TRIVIAL,UNSPECIFIED
 #
-# Scan-as-a-Service (scaas)
-# If Scan-as-a-Service is enabled, Scanner and Inspector *should* be disabled
-blackduck.artifactory.scaas.enabled=false
-blackduck.artifactory.scaas.blocking.strategy=BLOCK_NONE
-blackduck.artifactory.scaas.blocking.repos=ext-release-local,libs-release
-blackduck.artifactory.scaas.blocking.repos.csv.path=
+# Scan-as-a-Service (scaaas)
+# If Scan-as-a-Service is enabled, Scanner and Inspector *will* be disabled
+blackduck.artifactory.scaaas.enabled=false
+blackduck.artifactory.scaaas.blocking.strategy=BLOCK_NONE
+blackduck.artifactory.scaaas.blocking.repos=ext-release-local,libs-release
+blackduck.artifactory.scaaas.blocking.repos.csv.path=
 # Download of items prior to this date will be ALLOWED regardless of the
-# value of blackduck.artifactory.scaas.blocking.strategy
+# value of blackduck.artifactory.scaaas.blocking.strategy
 # This date MUST comply with the format in blackduck.date.time.pattern
 blackduck.artifactory.scaas.cutoff.date=
 #


### PR DESCRIPTION
Provide support for SCA-as-a-Service:
* Created new module `ScanAsAService`:
  * Ensure current `ScanModule` and `InspectModule` are disabled when using `ScanAsAService` module
  * Block downloads of unscanned item based on supplied blocking strategy for configured repositories
  * Block/Allow download of scanned items based on annotations written from SCA-as-a-Service
* New configuration items for module
  * Enable/Disable
  * Provide a Blocking Strategy
  * Provide a list of repos to apply blocking strategy
  * Provide a cutoff date to bypass blocking strategy