### PR TITLE
IARTH-484: Align property names with SCA-as-a-Service annotation names

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
@@ -37,7 +37,7 @@ public enum BlackDuckArtifactoryProperty {
     POST_SCAN_ACTION_STATUS("postScanActionStatus"),
     POST_SCAN_PHASE("postScanPhase"),
     INSPECTION_RETRY_COUNT("inspectionRetryCount"),
-    SCAAAS_SCAN_STATUS("scaaas.inspectionStatus"),
+    SCAAAS_SCAN_STATUS("scaaas.scanStatus"),
     SCAAAS_POLICY_STATUS("scaaas.policyStatus");
 
     private final String propertyName;


### PR DESCRIPTION
Modify `BlackDuckArtifactoryProperty.SCAAAS_SCAN_STATUS` from `scaaas.inspectionStatus` to `scaaas.scanStatus` to align with the annotation name being used by the Scan-as-a-Service Scanner.