### PR TITLE
IARTH-488: Provide a way to reset properties set by ScanAsAService

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/ArtifactoryPAPIService.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/ArtifactoryPAPIService.java
@@ -13,6 +13,7 @@ import java.util.Map;
 import java.util.Optional;
 
 import org.apache.commons.lang3.StringUtils;
+import org.artifactory.common.StatusHolder;
 import org.artifactory.fs.FileLayoutInfo;
 import org.artifactory.fs.ItemInfo;
 import org.artifactory.md.Properties;
@@ -137,5 +138,9 @@ public class ArtifactoryPAPIService {
 
     public ResourceStreamHandle getArtifactContent(RepoPath repoPath) {
         return repositories.getContent(repoPath);
+    }
+
+    public StatusHolder deleteItem(RepoPath repoPath) {
+        return repositories.delete(repoPath);
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/BlackDuckArtifactoryProperty.java
@@ -7,6 +7,10 @@
  */
 package com.synopsys.integration.blackduck.artifactory;
 
+import java.util.Set;
+
+import org.apache.commons.collections.set.UnmodifiableSet;
+
 public enum BlackDuckArtifactoryProperty {
     @Deprecated
     BLACKDUCK_ORIGIN_ID("originId"),
@@ -38,10 +42,24 @@ public enum BlackDuckArtifactoryProperty {
     POST_SCAN_PHASE("postScanPhase"),
     INSPECTION_RETRY_COUNT("inspectionRetryCount"),
     SCAAAS_SCAN_STATUS("scaaas.scanStatus"),
-    SCAAAS_POLICY_STATUS("scaaas.policyStatus");
+    SCAAAS_POLICY_STATUS("scaaas.policyStatus"),
+    SCAAAS_FAILED_COUNT("scaaas.scanFailedCount"),
+    SCAAAS_LAST_UPDATE("scaaas.lastUpdate"),
+    SCAAAS_RESULTS_URL("scaaas.resultsUrl"),
+    SCAAAS_SCAN_FAILURE_MESSAGE("scaaas.scanFailureMessage"),
+    SCAAAS_VIOLATING_POLICY_RULES("scaaas.violatingPolicyRules");
 
     private final String propertyName;
     private final String timeName;
+
+    private static final Set<BlackDuckArtifactoryProperty> scaaasProperties = Set.of(
+            SCAAAS_SCAN_STATUS,
+            SCAAAS_POLICY_STATUS,
+            SCAAAS_FAILED_COUNT,
+            SCAAAS_LAST_UPDATE,
+            SCAAAS_RESULTS_URL,
+            SCAAAS_SCAN_FAILURE_MESSAGE,
+            SCAAAS_VIOLATING_POLICY_RULES);
 
     BlackDuckArtifactoryProperty(String suffix) {
         propertyName = "blackduck." + suffix;
@@ -54,5 +72,9 @@ public enum BlackDuckArtifactoryProperty {
 
     public String getTimeName() {
         return timeName;
+    }
+
+    public static Set<BlackDuckArtifactoryProperty> getScanAsAServiceProperties() {
+        return scaaasProperties;
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
@@ -208,6 +208,8 @@ public class ModuleFactory {
         ScanAsAServicePropertyService scanAsAServicePropertyService = new ScanAsAServicePropertyService(artifactoryPAPIService, dateTimeManager);
         ScanAsAServiceCancelDecider scanAsAServiceCancelDecider = new ScanAsAServiceCancelDecider(scanAsAServiceModuleConfig, scanAsAServicePropertyService, artifactoryPAPIService);
         return new ScanAsAServiceModule(scanAsAServiceModuleConfig,
+                artifactoryPropertyService,
+                artifactoryPAPIService,
                 Arrays.asList(scanAsAServiceCancelDecider));
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/PluginAPI.java
@@ -165,6 +165,10 @@ public class PluginAPI implements Analyzable {
         runMethod(scanAsAServiceModule, triggerType, request, repoPath, scanAsAServiceModule::handleBeforeDownloadEvent);
     }
 
+    public String performDeleteScanAsAServicePropertiesOnRepos(TriggerType triggerType, Map<String, List<String>> params) {
+        return runMethod(scanAsAServiceModule, triggerType, () -> scanAsAServiceModule.deleteScanAsAServicePropertiesOnRepos(params));
+    }
+
     /**
      * Below are utility methods to help reuse the code for logging and analytics
      */

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModule.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModule.java
@@ -79,15 +79,13 @@ public class ScanAsAServiceModule implements Module {
     }
 
     public String deleteScanAsAServicePropertiesOnRepos(Map<String, List<String>> params) {
-        // A list pf repos should be provided in the params. If no repos provided, send error message
+        // A list of repos should be provided in the params. If no repos provided, send error message
         if (!params.containsKey("repos")) {
             return "Unable to execute. Please check that a list of repos is provided.";
         }
-        List<String> configuredRepos = scanAsAServiceModuleConfig.getBlockingRepos();
-        List<String> requestedRepos = params.get("repos");
-        List<String> reposToCheck = requestedRepos.stream().filter(configuredRepos::contains).collect(Collectors.toList());
+        List<String> reposToCheck = params.get("repos");
         if (reposToCheck.isEmpty()) {
-            return "Unable to execute. Provided repo list not a subset of " + ScanAsAServiceModuleProperty.BLOCKING_REPOS.getKey();
+            return "Unable to execute; Empty repos list";
         }
         Set<RepoPath> finalRepoPathSet = new HashSet<>();
         for (String repo : reposToCheck) {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModule.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModule.java
@@ -7,14 +7,25 @@
  */
 package com.synopsys.integration.blackduck.artifactory.modules.scaaas;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 
+import org.artifactory.common.StatusHolder;
 import org.artifactory.repo.RepoPath;
+import org.artifactory.repo.RepoPathFactory;
 import org.artifactory.request.Request;
 import org.slf4j.LoggerFactory;
 
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
+import com.synopsys.integration.blackduck.artifactory.ArtifactoryPropertyService;
+import com.synopsys.integration.blackduck.artifactory.BlackDuckArtifactoryProperty;
 import com.synopsys.integration.blackduck.artifactory.modules.Module;
 import com.synopsys.integration.blackduck.artifactory.modules.analytics.collector.AnalyticsCollector;
 import com.synopsys.integration.blackduck.artifactory.modules.cancel.CancelDecider;
@@ -28,11 +39,19 @@ public class ScanAsAServiceModule implements Module {
 
     private final ScanAsAServiceModuleConfig scanAsAServiceModuleConfig;
 
+    private final ArtifactoryPropertyService artifactoryPropertyService;
+
+    private final ArtifactoryPAPIService artifactoryPAPIService;
+
     private final Collection<CancelDecider> cancelDeciders;
 
     public ScanAsAServiceModule(ScanAsAServiceModuleConfig scanAsAServiceModuleConfig,
+            ArtifactoryPropertyService artifactoryPropertyService,
+            ArtifactoryPAPIService artifactoryPAPIService,
             Collection<CancelDecider> cancelDeciders) {
         this.scanAsAServiceModuleConfig = scanAsAServiceModuleConfig;
+        this.artifactoryPropertyService = artifactoryPropertyService;
+        this.artifactoryPAPIService = artifactoryPAPIService;
         this.cancelDeciders = cancelDeciders;
     }
 
@@ -57,5 +76,73 @@ public class ScanAsAServiceModule implements Module {
         } else {
             logger.info(String.format("BlackDuck Header present; Allowing download: repo: %s", repoPath));
         }
+    }
+
+    public String deleteScanAsAServicePropertiesOnRepos(Map<String, List<String>> params) {
+        // A list pf repos should be provided in the params. If no repos provided, send error message
+        if (!params.containsKey("repos")) {
+            return "Unable to execute. Please check that a list of repos is provided.";
+        }
+        List<String> configuredRepos = scanAsAServiceModuleConfig.getBlockingRepos();
+        List<String> requestedRepos = params.get("repos");
+        List<String> reposToCheck = requestedRepos.stream().filter(configuredRepos::contains).collect(Collectors.toList());
+        if (reposToCheck.isEmpty()) {
+            return "Unable to execute. Provided repo list not a subset of " + ScanAsAServiceModuleProperty.BLOCKING_REPOS.getKey();
+        }
+        Set<RepoPath> finalRepoPathSet = new HashSet<>();
+        for (String repo : reposToCheck) {
+            Set<RepoPath> repoPathSet = BlackDuckArtifactoryProperty.getScanAsAServiceProperties().stream()
+                    .map(property -> artifactoryPropertyService.getItemsContainingProperties(repo, property))
+                    .flatMap(List::stream)
+                    .collect(Collectors.toSet());
+            finalRepoPathSet.addAll(repoPathSet);
+        }
+        if (finalRepoPathSet.isEmpty()) {
+            return "Finished; No file in repo(s) with ScanAsAService properties were found";
+        }
+        return deleteScanAsAServiceProperties(finalRepoPathSet);
+    }
+
+    private String deleteScanAsAServiceProperties(Set<RepoPath> artifacts) {
+        StringBuilder resultMsg = new StringBuilder("The following actions were taken:").append("\n");
+        for (RepoPath repo : artifacts) {
+            BlackDuckArtifactoryProperty.getScanAsAServiceProperties().stream()
+                    .filter(property -> artifactoryPropertyService.hasProperty(repo, property))
+                    .forEach(property -> {
+                        if (BlackDuckArtifactoryProperty.SCAAAS_RESULTS_URL == property) {
+                            Optional<String> url = artifactoryPropertyService.getProperty(repo, property);
+                            logger.debug(String.format("Attempting to remove item: [%s]", url));
+                            String message = url.map(this::fromUrl)
+                                    .map(artifactoryPAPIService::deleteItem)
+                                    .map(StatusHolder::isError)
+                                    .orElse(Boolean.TRUE).toString();
+                            resultMsg.append("Removed resultsUrl: [")
+                                    .append(url.orElse("NULL"))
+                                    .append("]; error: [")
+                                    .append(message).append("]\n");
+                        }
+                        artifactoryPropertyService.deleteProperty(repo, property, logger);
+                    });
+            resultMsg.append("Remove ScanAsAService properties from repo: [").append(repo.toPath()).append("]\n");
+        }
+        return resultMsg.toString();
+    }
+
+    private RepoPath fromUrl(String urlString) {
+        URL url = null;
+        try {
+            url = new URL(urlString);
+        } catch (MalformedURLException e) {
+            logger.debug(String.format("Could not form URL from string: [%s]", urlString), e);
+        }
+        logger.debug(String.format("Using URL path [%s] and context path [%s] to construct RepoPath", (url == null ? "NULL" : url.getPath()), "/artifactory/"));
+        String repoPathString = null;
+        if (url != null) {
+            repoPathString = url.getPath();
+            if (repoPathString.startsWith("/artifactory/")) {
+                repoPathString = repoPathString.replaceFirst("/artifactory/", "");
+            }
+        }
+        return (repoPathString == null ? null : RepoPathFactory.create(repoPathString));
     }
 }

--- a/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
+++ b/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
@@ -314,6 +314,19 @@ executions {
      * curl -X POST -u admin:password "http://ARTIFACTORY_SERVER/artifactory/api/plugins/execute/blackDuckSubmitAnalytics"*/
     blackDuckSubmitAnalytics(httpMethod: 'POST') { params -> message = pluginAPI.submitAnalytics(TriggerType.REST_REQUEST)
     }
+
+    //////////////////////////////////////////////// SCA-AS-A-SERVICE EXECUTIONS ////////////////////////////////////////////////
+
+    /**
+     * Removes all properties that were populated by the SCA-as-a-Service function for the repositories listed in the "repos" parameter as long as
+     * those repos also exist in the blackduck.artifactory.scaaas.blocking.repos property.
+     * If the property blackduck.scaaas.resultsUrl is set on an artifact, the file it points to will be deleted
+     *
+     * This can be triggered with the following curl command:
+     * curl -X POST -u admin:password "http://ARTIFACTORY_SERVER/artifactory/api/plugins/execute/blackDuckDeleteScanAsAServicePropertiesOnRepos?params=repos=repo1[,repo2 ...]
+     */
+    blackDuckDeleteScanAsAServicePropertiesOnRepos(httpMethod: 'POST') { params -> message = pluginAPI.performDeleteScanAsAServicePropertiesOnRepos(TriggerType.REST_REQUEST, (Map<String, List<String>>) params)
+    }
 }
 
 jobs {


### PR DESCRIPTION
* Added an REST Execution endpoint for ScanAsAService to allow the user to specify one or more repositories to remove all ScanAsAService properties for artifacts.
* If `resultUrl` is one of the properties on an artifact, remove the file specified by the property.

Closes IARTH-488