### PR TITLE
IARTH-487: Support for allowed/excluded file patterns

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
@@ -7,9 +7,12 @@
  */
 package com.synopsys.integration.blackduck.artifactory.modules.cancel;
 
+import java.io.File;
+import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.artifactory.fs.ItemInfo;
 import org.artifactory.repo.RepoPath;
 import org.slf4j.Logger;
@@ -64,108 +67,166 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
             return CancelDecision.NO_CANCELLATION();
         }
 
-        ScanAsAServiceBlockingStrategy blockingStrategy = moduleConfig.getBlockingStrategy();
-        Optional<ProjectVersionComponentPolicyStatusType> policyViolationStatus = propertyService.getPolicyStatus(repoPath);
-        return propertyService.getScanStatusProperty(repoPath).map(
-                        scanStatus -> {
-                            CancelDecision dec;
-                            switch (scanStatus) {
-                            case FAILED:
-                                if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
-                                    logger.info("Download NOT blocked; Blocking Strategy: {}; Download would have been blocked; {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), repoPath);
-                                    dec = CancelDecision.NO_CANCELLATION();
-                                } else {
-                                    dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
-                                }
-                                break;
-                            case PROCESSING:
-                                switch (blockingStrategy) {
-                                case BLOCK_ALL:
-                                    dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
-                                    break;
-                                case BLOCK_NONE:
-                                    dec = CancelDecision.NO_CANCELLATION();
-                                    break;
-                                case BLOCK_OFF:
-                                    logger.info("Download NOT Blocked; Blocking Strategy: {}; {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), repoPath);
-                                    dec = CancelDecision.NO_CANCELLATION();
-                                    break;
-                                default:
-                                    dec = CancelDecision.CANCEL_DOWNLOAD(
-                                            String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
-                                }
-                                break;
-                            case SUCCESS:
-                                if(policyViolationStatus.isPresent()) {
-                                    switch (policyViolationStatus.get()) {
-                                    case NOT_IN_VIOLATION:
+        File file = new File(itemInfo.getName());
+        Optional<List<String>> allowedNamePatterns = moduleConfig.getAllowedFileNamePatterns();
+        Optional<List<String>> excludedNamePatterns = moduleConfig.getExcludedFileNamePatterns();
+
+        if (applyBlockingStrategyBasedOnFilePattern(allowedNamePatterns.orElse(null), excludedNamePatterns.orElse(null), file)) {
+            ScanAsAServiceBlockingStrategy blockingStrategy = moduleConfig.getBlockingStrategy();
+            Optional<ProjectVersionComponentPolicyStatusType> policyViolationStatus = propertyService.getPolicyStatus(repoPath);
+            return propertyService.getScanStatusProperty(repoPath).map(
+                            scanStatus -> {
+                                CancelDecision dec;
+                                switch (scanStatus) {
+                                case FAILED:
+                                    if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
+                                        logger.info("Download NOT blocked; Blocking Strategy: {}; Download would have been blocked; {}; repo: {}",
+                                                ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), repoPath);
                                         dec = CancelDecision.NO_CANCELLATION();
-                                        break;
-                                    case IN_VIOLATION:
-                                        if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
-                                            logger.info("Download NOT blocked; Blocking Strategy: {}; {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), repoPath);
-                                            dec = CancelDecision.NO_CANCELLATION();
-                                        } else {
-                                            dec = CancelDecision.CANCEL_DOWNLOAD(
-                                                    String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", scanStatus.getMessage(),
-                                                            policyViolationStatus.get(), repoPath));
-                                        }
-                                        break;
-                                    default:
-                                        if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
-                                            logger.info("Download NOT blocked; Blocking Strategy: {}; {}; Unknown policy violation status: {}; repo: {}",
-                                                    ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), policyViolationStatus.get(), repoPath);
-                                            dec = CancelDecision.NO_CANCELLATION();
-                                        } else {
-                                            dec = CancelDecision.CANCEL_DOWNLOAD(
-                                                    String.format("Download blocked; %s; Unknown policy violation status: %s; repo: %s",
-                                                            scanStatus.getMessage(), policyViolationStatus.get(), repoPath));
-                                        }
+                                    } else {
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
                                     }
-                                } else {
-                                    logger.warn(String.format("%s; %s property not present; Using block strategy: %s; repo: %s", scanStatus.getMessage(),
-                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS.getPropertyName(), blockingStrategy, repoPath));
+                                    break;
+                                case PROCESSING:
                                     switch (blockingStrategy) {
                                     case BLOCK_ALL:
-                                        dec = CancelDecision.CANCEL_DOWNLOAD(
-                                            String.format("Download blocked; %s; %s not present; block strategy: %s; repo: %s", scanStatus.getMessage(), BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
                                         break;
                                     case BLOCK_NONE:
+                                        dec = CancelDecision.NO_CANCELLATION();
+                                        break;
                                     case BLOCK_OFF:
+                                        logger.info("Download NOT Blocked; Blocking Strategy: {}; {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF,
+                                                scanStatus.getMessage(), repoPath);
                                         dec = CancelDecision.NO_CANCELLATION();
                                         break;
                                     default:
                                         dec = CancelDecision.CANCEL_DOWNLOAD(
-                                                String.format("Download blocked; %s not present; Unknown blocking strategy: %s; repo: %s", BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                                String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                                    }
+                                    break;
+                                case SUCCESS:
+                                    if (policyViolationStatus.isPresent()) {
+                                        switch (policyViolationStatus.get()) {
+                                        case NOT_IN_VIOLATION:
+                                            dec = CancelDecision.NO_CANCELLATION();
+                                            break;
+                                        case IN_VIOLATION:
+                                            if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
+                                                logger.info("Download NOT blocked; Blocking Strategy: {}; {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF,
+                                                        scanStatus.getMessage(), repoPath);
+                                                dec = CancelDecision.NO_CANCELLATION();
+                                            } else {
+                                                dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                        String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", scanStatus.getMessage(),
+                                                                policyViolationStatus.get(), repoPath));
+                                            }
+                                            break;
+                                        default:
+                                            if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
+                                                logger.info("Download NOT blocked; Blocking Strategy: {}; {}; Unknown policy violation status: {}; repo: {}",
+                                                        ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), policyViolationStatus.get(), repoPath);
+                                                dec = CancelDecision.NO_CANCELLATION();
+                                            } else {
+                                                dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                        String.format("Download blocked; %s; Unknown policy violation status: %s; repo: %s",
+                                                                scanStatus.getMessage(), policyViolationStatus.get(), repoPath));
+                                            }
+                                        }
+                                    } else {
+                                        logger.warn(String.format("%s; %s property not present; Using block strategy: %s; repo: %s", scanStatus.getMessage(),
+                                                BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS.getPropertyName(), blockingStrategy, repoPath));
+                                        switch (blockingStrategy) {
+                                        case BLOCK_ALL:
+                                            dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                    String.format("Download blocked; %s; %s not present; block strategy: %s; repo: %s", scanStatus.getMessage(),
+                                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                            break;
+                                        case BLOCK_NONE:
+                                        case BLOCK_OFF:
+                                            dec = CancelDecision.NO_CANCELLATION();
+                                            break;
+                                        default:
+                                            dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                    String.format("Download blocked; %s not present; Unknown blocking strategy: %s; repo: %s",
+                                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                        }
+                                    }
+                                    break;
+                                default:
+                                    logger.warn(String.format("Unknown scan status detected: %s", scanStatus));
+                                    if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
+                                        logger.info("Download NOT blocked; Blocking Strategy: {}; Unknown ScanStatusProperty: {}; repo: {}",
+                                                ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus, repoPath);
+                                        dec = CancelDecision.NO_CANCELLATION();
+                                    } else {
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(
+                                                String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", scanStatus, repoPath));
                                     }
                                 }
-                                break;
-                            default:
-                                logger.warn(String.format("Unknown scan status detected: %s", scanStatus));
-                                if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
-                                    logger.info("Download NOT blocked; Blocking Strategy: {}; Unknown ScanStatusProperty: {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus, repoPath);
-                                    dec = CancelDecision.NO_CANCELLATION();
-                                } else {
-                                    dec = CancelDecision.CANCEL_DOWNLOAD(
-                                            String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", scanStatus, repoPath));
-                                }
-                            }
-                            return dec;
-                        })
-                .orElseGet(() ->{
+                                return dec;
+                            })
+                    .orElseGet(() -> {
                         switch (blockingStrategy) {
-                            case BLOCK_ALL:
-                                return CancelDecision.CANCEL_DOWNLOAD(
-                                        String.format("Download blocked; Scan not scheduled and blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
-                            case BLOCK_NONE:
-                                return CancelDecision.NO_CANCELLATION();
-                            case BLOCK_OFF:
-                                logger.info("Download NOT blocked; Blocking Strategy: {}; Scan not scheduled; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF, repoPath);
-                                return CancelDecision.NO_CANCELLATION();
-                            default:
-                                return CancelDecision.CANCEL_DOWNLOAD(
-                                        String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                        case BLOCK_ALL:
+                            return CancelDecision.CANCEL_DOWNLOAD(
+                                    String.format("Download blocked; Scan not scheduled and blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                        case BLOCK_NONE:
+                            return CancelDecision.NO_CANCELLATION();
+                        case BLOCK_OFF:
+                            logger.info("Download NOT blocked; Blocking Strategy: {}; Scan not scheduled; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF,
+                                    repoPath);
+                            return CancelDecision.NO_CANCELLATION();
+                        default:
+                            return CancelDecision.CANCEL_DOWNLOAD(
+                                    String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
                         }
+                    });
+        } else {
+            logger.info("Download NOT blocked; File allowed/excluded pattern check failed; repo: {}", repoPath);
+            return CancelDecision.NO_CANCELLATION();
+        }
+    }
+
+    /**
+     * Check to see if a given file is should be checked to see if the blocking strategy should be applied. If no allowed patterns are specified, then all
+     * files are subject to the blocking strategy.
+     *
+     * @param allowedPatterns String list of the allowed file patterns; null if none set
+     * @param excludedPatterns String list of the excluded file patterns; null if none set
+     * @param file File to check
+     * @return {@code true} if the pattern of the given file is in the allowedPatterns while at the same time NOT
+     * in the excludedPatterns; {@code false}, otherwise
+     */
+    private boolean applyBlockingStrategyBasedOnFilePattern(List<String> allowedPatterns, List<String> excludedPatterns, File file) {
+        AtomicBoolean ret = new AtomicBoolean(true);
+
+        Optional<WildcardFileFilter> allowedWildCardFilter = Optional.ofNullable(allowedPatterns == null ? null : new WildcardFileFilter(allowedPatterns));
+        Optional<WildcardFileFilter> excludedWildCardFilter = Optional.ofNullable(excludedPatterns == null ? null : new WildcardFileFilter(excludedPatterns));
+
+        // Check to see if there are include file patterns to check against
+        allowedWildCardFilter.ifPresentOrElse(allowedFilter -> {
+            if (allowedFilter.accept(file)) {
+                // Matches an include pattern set so now check if there are exclude patterns to check against
+                excludedWildCardFilter.ifPresent(excludeFilter -> {
+                    if (excludeFilter.accept(file)) {
+                        // Exclude pattern matched, do NOT apply blocking strategy
+                        ret.set(false);
+                    }
                 });
+            } else {
+                // Not in the include pattern set so do NOT apply blocking strategy
+                ret.set(false);
+            }
+        }, () -> {
+            // There are no include patterns so check if there are exclude patterns
+            excludedWildCardFilter.ifPresent(excludeFilter -> {
+                if (excludeFilter.accept(file)) {
+                    // Exclude pattern matched, do NOT apply blocking strategy
+                    ret.set(false);
+                }
+            });
+        });
+        return ret.get();
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleConfig.java
@@ -33,6 +33,10 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
 
     private final DateTimeManager dateTimeManager;
 
+    private final List<String> allowedFileNamePatterns;
+
+    private final List<String> excludedFileNamePatterns;
+
 
     protected ScanAsAServiceModuleConfig(Builder builder) {
         super(ScanAsAServiceModule.class.getSimpleName(), builder.enabled);
@@ -40,6 +44,8 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         this.blockingRepos = new ArrayList<>(builder.blockingRepos);
         this.cutoffDateString = builder.cutoffDateString;
         this.dateTimeManager = builder.dateTimeManager;
+        this.allowedFileNamePatterns = builder.allowedFileNamePatterns.isEmpty() ? null : new ArrayList<>(builder.allowedFileNamePatterns);
+        this.excludedFileNamePatterns = builder.excludedFileNamePatterns.isEmpty() ? null : new ArrayList<>(builder.excludedFileNamePatterns);
     }
 
     public static ScanAsAServiceModuleConfig createFromProperties(ConfigurationPropertyManager configurationPropertyManager,
@@ -72,6 +78,14 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
             if ((cutoffDateString = configurationPropertyManager.getProperty(ScanAsAServiceModuleProperty.CUTOFF_DATE)) != null) {
                 moduleConfig.withCutoffDateString(cutoffDateString);
             }
+            List<String> allowedFileNamePatterns = configurationPropertyManager.getPropertyAsList(ScanAsAServiceModuleProperty.ALLOWED_FILE_PATTERNS);
+            if (!allowedFileNamePatterns.isEmpty()) {
+                moduleConfig.withAllowedFileNamePatters(allowedFileNamePatterns);
+            }
+            List<String> excludedFileNamePatterns = configurationPropertyManager.getPropertyAsList(ScanAsAServiceModuleProperty.EXCLUDED_FILE_PATTERNS);
+            if(!excludedFileNamePatterns.isEmpty()) {
+                moduleConfig.withExcludedFileNamePatterns(excludedFileNamePatterns);
+            }
         }
 
         return moduleConfig.build();
@@ -93,6 +107,14 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         return this.dateTimeManager;
     }
 
+    public Optional<List<String>> getAllowedFileNamePatterns() {
+        return Optional.ofNullable(this.allowedFileNamePatterns);
+    }
+
+    public Optional<List<String>> getExcludedFileNamePatterns() {
+        return Optional.ofNullable(this.excludedFileNamePatterns);
+    }
+
     @Override
     public void validate(PropertyGroupReport propertyGroupReport, List<String> enabledModules) {
         if (isEnabled()) {
@@ -111,8 +133,9 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         private ScanAsAServiceBlockingStrategy blockingStrategy;
         private List<String> blockingRepos = new ArrayList<>();
         private String cutoffDateString;
-
         private DateTimeManager dateTimeManager;
+        private List<String> allowedFileNamePatterns = new ArrayList<>();
+        private List<String> excludedFileNamePatterns = new ArrayList<>();
 
         private Builder(Boolean enabled, DateTimeManager dateTimeManager) {
             this.enabled = enabled;
@@ -135,6 +158,16 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
 
         public Builder withCutoffDateString(String cutoffDateString) {
             this.cutoffDateString = cutoffDateString;
+            return this;
+        }
+
+        public Builder withAllowedFileNamePatters(List<String> allowedFileNamePatterns) {
+            this.allowedFileNamePatterns.addAll(allowedFileNamePatterns);
+            return this;
+        }
+
+        public Builder withExcludedFileNamePatterns(List<String> excludedFileNamePatterns) {
+            this.excludedFileNamePatterns.addAll(excludedFileNamePatterns);
             return this;
         }
 

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleProperty.java
@@ -15,6 +15,8 @@ public enum ScanAsAServiceModuleProperty implements ConfigurationProperty {
     BLOCKING_REPOS("blocking.repos"),
     BLOCKING_REPOS_CSV_PATH("blocking.repos.csv.path"),
     CUTOFF_DATE("cutoff.date"),
+    ALLOWED_FILE_PATTERNS("allowed.patterns"),
+    EXCLUDED_FILE_PATTERNS("excluded.patterns"),
     ;
 
     private static final String SCAN_AS_A_SERVICE_MODULE_PROPERTY_PREFIX = "blackduck.artifactory.scaaas.";

--- a/src/main/resources/blackDuckPlugin.properties
+++ b/src/main/resources/blackDuckPlugin.properties
@@ -75,6 +75,8 @@ blackduck.artifactory.scaaas.enabled=false
 blackduck.artifactory.scaaas.blocking.strategy=BLOCK_NONE
 blackduck.artifactory.scaaas.blocking.repos=ext-release-local,libs-release
 blackduck.artifactory.scaaas.blocking.repos.csv.path=
+blackduck.artifactory.scaaas.allowed.patterns=
+blackduck.artifactory.scaaas.excluded.patterns=
 # Download of items prior to this date will be ALLOWED regardless of the
 # value of blackduck.artifactory.scaaas.blocking.strategy
 # This date MUST comply with the format in blackduck.date.time.pattern


### PR DESCRIPTION
Support a comma-separated list of allowed/excluded file pattern to allow/exclude files from being considered to having the blocking strategy applied. The allowed/excluded list follows these rules:
* If the allowed pattern is not specified and the exclude pattern is not specified, the file is checked against the blocking strategy;
* If the allowed pattern is not specified and the exclude pattern is specified the file will be check against the exclude pattern to see if it should then be checked against blocking strategy;
* If the allowed pattern is present and the file matches, and the exclude pattern is not specified, the file is checked against the blocking strategy;
* If the allowed pattern is present and the file matches and the exclude pattern is present the file is checked against both to see if it should  then be checked against the blocking pattern;
* If the allowed pattern is present and the file does not match, the fie is NOT checked against the blocking strategy (no checking against an exclude pattern is needed);

Reorganized ScanAsAServiceCancelDeciderTest to group tests better

Closes IARTH-487