### PR TITLE
IARTH-489: no block download when scanStatus=FAILED and blockingStrategy=BLOCK_NONE

### DIFF
--- a/blackduck-artifactory-common/build.gradle
+++ b/blackduck-artifactory-common/build.gradle
@@ -12,6 +12,9 @@ apply plugin: 'com.synopsys.integration.simple'
 apply plugin: 'kotlin'
 apply plugin: 'java-library'
 
+sourceCompatibility = 9
+targetCompatibility = 9
+
 jar.finalizedBy shadowJar
 
 dependencies {

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
@@ -79,12 +79,21 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
                                 CancelDecision dec;
                                 switch (scanStatus) {
                                 case FAILED:
-                                    if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
+                                    switch (blockingStrategy) {
+                                    case BLOCK_ALL:
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
+                                        break;
+                                    case BLOCK_NONE:
+                                        logger.info("Download NOT blocked; Blocking Strategy: {}; {}; repo: {}", blockingStrategy, scanStatus.getMessage(), repoPath);
+                                        dec = CancelDecision.NO_CANCELLATION();
+                                        break;
+                                    case BLOCK_OFF:
                                         logger.info("Download NOT blocked; Blocking Strategy: {}; Download would have been blocked; {}; repo: {}",
                                                 ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), repoPath);
                                         dec = CancelDecision.NO_CANCELLATION();
-                                    } else {
-                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
+                                        break;
+                                    default:
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
                                     }
                                     break;
                                 case PROCESSING:

--- a/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
@@ -88,7 +88,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         BLOCK_NONE,
                         FAILED,
                         null,
-                        CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", FAILED.getMessage(), artifactPath)))
+                        CancelDecision.NO_CANCELLATION())
         );
     }
 

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,8 @@ build.finalizedBy createFinalZip
 configure(subprojects) { project ->
     group = 'com.synopsys.integration'
     version = parentVersion
-    sourceCompatibility = 11
+    sourceCompatibility = 9
+    targetCompatibility = 9
     dependencies {
         ext.artifactoryMinimumVersion = artifactoryMinimumVersion
         ext.blackDuckCommonVersion = blackDuckCommonVersion


### PR DESCRIPTION
* Changed behavior when scanResult=FAILED and blockingStrategy=BLOCK_NONE from blocking to download to allowing the download
* Updated build scripts to reflect Java source and target compatibility