### PR TITLE
IARTH-487: Add better logging and change unit tests to use more realistic file name

### DIFF
--- a/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
+++ b/blackduck-artifactory-common/src/test/java/cancel/ScanAsAServiceCancelDeciderTest.java
@@ -58,7 +58,7 @@ public class ScanAsAServiceCancelDeciderTest {
 
     private static String TEST_OUTSIDE_REPO_PATH = "test-outside-repo";
 
-    private static String TEST_ARTIFACT_NAME = "test-artifact.jar";
+    private static String TEST_ARTIFACT_NAME = "test-artifact-2.1.jar";
 
     private static String DATETIME_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS";
 
@@ -221,7 +221,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         SUCCESS,
                         IN_VIOLATION, // The combination of these will cause blocking if the allowed file pattern check fails
                         null,
-                        List.of("*fact.jar"),
+                        List.of("*fact*.jar"),
                         CancelDecision.NO_CANCELLATION()),
                 arguments("Blocking; Allowed File Pattern not specified; Exclude File Pattern not matched",
                         artifactPath,
@@ -229,7 +229,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         SUCCESS,
                         IN_VIOLATION,
                         null,
-                        List.of("*fact.war"),
+                        List.of("*fact*.war"),
                         CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath))),
                 arguments("Blocking; Allowed File Pattern matched; Exclude File Pattern not specified",
                         artifactPath,
@@ -245,7 +245,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         SUCCESS,
                         IN_VIOLATION, // The combination of these will cause blocking if the allowed file pattern check fails
                         List.of("*.war", "*.jar"),
-                        List.of("*fact.jar"),
+                        List.of("*fact*.jar"),
                         CancelDecision.NO_CANCELLATION()),
                 arguments("Blocking; Allowed File Pattern matched; Exclude File Pattern not matched",
                         artifactPath,
@@ -253,7 +253,7 @@ public class ScanAsAServiceCancelDeciderTest {
                         SUCCESS,
                         IN_VIOLATION,
                         List.of("*.war", "*.jar"),
-                        List.of("*fact.war"),
+                        List.of("*fact*.war"),
                         CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", SUCCESS.getMessage(), IN_VIOLATION.name(), artifactPath))),
                 arguments("No Blocking; Allowed File Pattern not matched",
                         artifactPath,


### PR DESCRIPTION
* Added debug logging to determine the allowed/excluded filter path used when deciding whether to apply the blocking strategy to a file 
* Changed file name used in unit tests to be more realistic