### PR TITLE
IARTH-496: Add new configuration property for Docker repos

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleConfig.java
@@ -12,7 +12,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleConfig.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleConfig.java
@@ -12,6 +12,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -39,6 +40,8 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
 
     private final List<String> excludedFileNamePatterns;
 
+    private final List<String>  blockingDockerRepos;
+
 
     protected ScanAsAServiceModuleConfig(Builder builder) {
         super(ScanAsAServiceModule.class.getSimpleName(), builder.enabled);
@@ -48,6 +51,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         this.dateTimeManager = builder.dateTimeManager;
         this.allowedFileNamePatterns = builder.allowedFileNamePatterns.isEmpty() ? null : new ArrayList<>(builder.allowedFileNamePatterns);
         this.excludedFileNamePatterns = builder.excludedFileNamePatterns.isEmpty() ? null : new ArrayList<>(builder.excludedFileNamePatterns);
+        this.blockingDockerRepos = builder.blockingDockerRepos.isEmpty() ? null : new ArrayList<>(builder.blockingDockerRepos);
     }
 
     public static ScanAsAServiceModuleConfig createFromProperties(ConfigurationPropertyManager configurationPropertyManager,
@@ -71,21 +75,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
             moduleConfig.withBlockingStrategy(blockingStrategy);
             List<String> repos = configurationPropertyManager.getRepositoryKeysFromProperties(ScanAsAServiceModuleProperty.BLOCKING_REPOS, ScanAsAServiceModuleProperty.BLOCKING_REPOS_CSV_PATH)
                     .stream()
-                    .map(repo -> {
-                        String cleaned = StringUtils.deleteWhitespace(repo);
-                        if (cleaned.endsWith("/")) {
-                            cleaned = cleaned.substring(0, cleaned.lastIndexOf("/"));
-                        }
-                        if (cleaned.startsWith("/")) {
-                            cleaned = cleaned.substring(1);
-                        }
-
-                        String[] split = cleaned.split("/");
-                        if (split.length == 0 || !artifactoryPAPIService.isValidRepository(split[0])) {
-                            return null;
-                        }
-                        return cleaned;
-                    })
+                    .map(repo -> cleanRepoName(repo, artifactoryPAPIService))
                     .filter(Objects::nonNull)
                     .collect(Collectors.toList());
             if (!repos.isEmpty()) {
@@ -102,6 +92,14 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
             List<String> excludedFileNamePatterns = configurationPropertyManager.getPropertyAsList(ScanAsAServiceModuleProperty.EXCLUDED_FILE_PATTERNS);
             if(!excludedFileNamePatterns.isEmpty()) {
                 moduleConfig.withExcludedFileNamePatterns(excludedFileNamePatterns);
+            }
+            List<String> dockerRepos = configurationPropertyManager.getRepositoryKeysFromProperties(ScanAsAServiceModuleProperty.BLOCKING_DOCKER_REPOS, ScanAsAServiceModuleProperty.BLOCKING_DOCKER_REPOS_CSV_PATH)
+                    .stream()
+                    .map(repo -> ScanAsAServiceModuleConfig.cleanRepoName(repo, artifactoryPAPIService))
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList());
+            if (!dockerRepos.isEmpty()) {
+                moduleConfig.withBlockingDockerRepos(dockerRepos);
             }
         }
 
@@ -132,6 +130,10 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         return Optional.ofNullable(this.excludedFileNamePatterns);
     }
 
+    public Optional<List<String>> getBlockingDockerRepos() {
+        return Optional.ofNullable(this.blockingDockerRepos);
+    }
+
     @Override
     public void validate(PropertyGroupReport propertyGroupReport, List<String> enabledModules) {
         if (isEnabled()) {
@@ -145,6 +147,22 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         }
     }
 
+    private static String cleanRepoName(String repo, ArtifactoryPAPIService artifactoryPAPIService) {
+        String cleaned = StringUtils.deleteWhitespace(repo);
+        if (cleaned.endsWith("/")) {
+            cleaned = cleaned.substring(0, cleaned.lastIndexOf("/"));
+        }
+        if (cleaned.startsWith("/")) {
+            cleaned = cleaned.substring(1);
+        }
+
+        String[] split = cleaned.split("/");
+        if (split.length == 0 || !artifactoryPAPIService.isValidRepository(split[0])) {
+            return null;
+        }
+        return cleaned;
+    }
+
     public static class Builder {
         private Boolean enabled;
         private ScanAsAServiceBlockingStrategy blockingStrategy;
@@ -153,6 +171,7 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
         private DateTimeManager dateTimeManager;
         private List<String> allowedFileNamePatterns = new ArrayList<>();
         private List<String> excludedFileNamePatterns = new ArrayList<>();
+        private List<String> blockingDockerRepos = new ArrayList<>();
 
         private Builder(Boolean enabled, DateTimeManager dateTimeManager) {
             this.enabled = enabled;
@@ -185,6 +204,11 @@ public class ScanAsAServiceModuleConfig extends ModuleConfig {
 
         public Builder withExcludedFileNamePatterns(List<String> excludedFileNamePatterns) {
             this.excludedFileNamePatterns.addAll(excludedFileNamePatterns);
+            return this;
+        }
+
+        public Builder withBlockingDockerRepos(List<String> repos) {
+            this.blockingDockerRepos.addAll(repos);
             return this;
         }
 

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleProperty.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/scaaas/ScanAsAServiceModuleProperty.java
@@ -17,6 +17,8 @@ public enum ScanAsAServiceModuleProperty implements ConfigurationProperty {
     CUTOFF_DATE("cutoff.date"),
     ALLOWED_FILE_PATTERNS("allowed.patterns"),
     EXCLUDED_FILE_PATTERNS("excluded.patterns"),
+    BLOCKING_DOCKER_REPOS("blocking.docker.repos"),
+    BLOCKING_DOCKER_REPOS_CSV_PATH("blocking.docker.repos.csv.path"),
     ;
 
     private static final String SCAN_AS_A_SERVICE_MODULE_PROPERTY_PREFIX = "blackduck.artifactory.scaaas.";

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
     id 'org.jetbrains.kotlin.jvm' version '1.3.31'
 }
 
-version = '9.0.1-SNAPSHOT'
+version = '10.0.0-SNAPSHOT'
 
 final String parentVersion = project.version
 

--- a/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
+++ b/src/main/groovy/com/synopsys/integration/blackduck/artifactory/blackDuckPlugin.groovy
@@ -1,7 +1,7 @@
 /*
  * blackduck-artifactory
  *
- * Copyright (c) 2022 Synopsys, Inc.
+ * Copyright (c) 2023 Synopsys, Inc.
  *
  * Use subject to the terms and conditions of the Synopsys End User Software License and Maintenance Agreement. All rights reserved worldwide.
  */

--- a/src/main/resources/blackDuckPlugin.properties
+++ b/src/main/resources/blackDuckPlugin.properties
@@ -81,6 +81,12 @@ blackduck.artifactory.scaaas.excluded.patterns=
 # value of blackduck.artifactory.scaaas.blocking.strategy
 # This date MUST comply with the format in blackduck.date.time.pattern
 blackduck.artifactory.scaaas.cutoff.date=
+# blocking.docker.repos and blocking.docker.repos.csv.path contain the list of repositories
+# that are defined in Artifactory as Docker repositories. These MUST be specified explicitly
+# and DO NOT have to be specified as part of blocking.repos or blocking.repos.csv.path.
+# If empty, assumes NO repositories are of type Docker.
+blackduck.artifactory.scaaas.blocking.docker.repos=ext-docker-repo
+blackduck.artifactory.scaaas.blocking.docker.repos.csv.path=
 #
 # Analytics
 blackduck.artifactory.analytics.enabled=true


### PR DESCRIPTION
* Create new configuration property for ScanAsAService to contain the list or path to file containing CSV list of repositories designated as Docker repositories.
* Process configuration property and add to ScanAsAService module config.

Closes IARTH-496