### PR TITLE
IARTH-497 Apply blocking strategy to Docker Repos

### DIFF
--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/PluginRepoPath.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/PluginRepoPath.java
@@ -10,7 +10,6 @@ package com.synopsys.integration.blackduck.artifactory;
 import java.io.File;
 import java.nio.file.Path;
 import java.util.Objects;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
@@ -96,5 +95,10 @@ public class PluginRepoPath implements RepoPath {
     @Override
     public int hashCode() {
         return Objects.hash(getRepoKey(), repoPath);
+    }
+
+    @Override
+    public String toString() {
+        return this.getId();
     }
 }

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/ModuleFactory.java
@@ -206,7 +206,8 @@ public class ModuleFactory {
     public ScanAsAServiceModule createScanAsAServiceModule() throws IOException {
         ScanAsAServiceModuleConfig scanAsAServiceModuleConfig = ScanAsAServiceModuleConfig.createFromProperties(configurationPropertyManager, artifactoryPAPIService, dateTimeManager);
         ScanAsAServicePropertyService scanAsAServicePropertyService = new ScanAsAServicePropertyService(artifactoryPAPIService, dateTimeManager);
-        ScanAsAServiceCancelDecider scanAsAServiceCancelDecider = new ScanAsAServiceCancelDecider(scanAsAServiceModuleConfig, scanAsAServicePropertyService, artifactoryPAPIService);
+        PluginRepoPathFactory pluginRepoPathFactory = new PluginRepoPathFactory();
+        ScanAsAServiceCancelDecider scanAsAServiceCancelDecider = new ScanAsAServiceCancelDecider(scanAsAServiceModuleConfig, scanAsAServicePropertyService, pluginRepoPathFactory, artifactoryPAPIService);
         return new ScanAsAServiceModule(scanAsAServiceModuleConfig,
                 artifactoryPropertyService,
                 artifactoryPAPIService,

--- a/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
+++ b/blackduck-artifactory-common/src/main/java/com/synopsys/integration/blackduck/artifactory/modules/cancel/ScanAsAServiceCancelDecider.java
@@ -11,6 +11,7 @@ import java.io.File;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
 
 import org.apache.commons.io.filefilter.WildcardFileFilter;
 import org.artifactory.fs.ItemInfo;
@@ -18,9 +19,11 @@ import org.artifactory.repo.RepoPath;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.MoreObjects;
 import com.synopsys.integration.blackduck.api.generated.enumeration.ProjectVersionComponentPolicyStatusType;
 import com.synopsys.integration.blackduck.artifactory.ArtifactoryPAPIService;
 import com.synopsys.integration.blackduck.artifactory.BlackDuckArtifactoryProperty;
+import com.synopsys.integration.blackduck.artifactory.PluginRepoPathFactory;
 import com.synopsys.integration.blackduck.artifactory.modules.scaaas.ScanAsAServiceBlockingStrategy;
 import com.synopsys.integration.blackduck.artifactory.modules.scaaas.ScanAsAServiceModuleConfig;
 import com.synopsys.integration.blackduck.artifactory.modules.scaaas.ScanAsAServicePropertyService;
@@ -32,104 +35,147 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
 
     private final ScanAsAServicePropertyService propertyService;
 
+    private final PluginRepoPathFactory repoPathFactory;
+
     private final ArtifactoryPAPIService artifactoryPAPIService;
+
+    private final BiFunction<String, RepoPath, Boolean> pathInManagedRepo = (block, repo) -> {
+        // If any blocking repo matches these predicates then continue validation
+        // If no blocking repo matches then we can short circuit with no-cancellation
+        if (!block.contains("/") && block.equals(repo.getRepoKey())) {
+            logger.trace(String.format("Found folder match; repo: %s", repo));
+            return true;
+        } else if (block.contains("/")) {
+            // If block includes a branch, need to check against repo and path
+            String wholePath = repo.toPath();
+            // Not equal check since need to validate when block=repo/branch and repoAndPath=repo/branch/child
+            String regex = "^" + block + "/.*";
+            if (wholePath.matches(regex)) {
+                logger.trace(String.format("Found folder match (whole path); repo: %s", repo));
+                return true;
+            }
+        }
+        logger.trace(String.format("No folder match; repo: %s", repo));
+        return false;
+    };
 
     public ScanAsAServiceCancelDecider(ScanAsAServiceModuleConfig moduleConfig,
             ScanAsAServicePropertyService propertyService,
+            PluginRepoPathFactory repoPathFactory,
             ArtifactoryPAPIService artifactoryPAPIService) {
         this.moduleConfig = moduleConfig;
         this.propertyService = propertyService;
+        this.repoPathFactory = repoPathFactory;
         this.artifactoryPAPIService = artifactoryPAPIService;
     }
 
     @Override
     public CancelDecision getCancelDecision(RepoPath repoPath) {
+        AtomicBoolean isManagedDockerRepo = new AtomicBoolean(false);
 
         ItemInfo itemInfo = artifactoryPAPIService.getItemInfo(repoPath);
+        logger.debug(displayItemInfo(itemInfo));
+
         if (itemInfo.isFolder()) {
-            return CancelDecision.NO_CANCELLATION();
+            // Check to see if it is a Docker Repo being managed
+            moduleConfig.getBlockingDockerRepos().ifPresent(dockerRepos -> {
+                isManagedDockerRepo.set(dockerRepos.stream().anyMatch(block -> pathInManagedRepo.apply(block, repoPath)));
+            });
+
+            if (!isManagedDockerRepo.get()) {
+                // This is a regular folder and not a Docker Repo being managed
+                return CancelDecision.NO_CANCELLATION();
+            }
         }
 
-        if (!moduleConfig.getBlockingRepos().stream()
-                .anyMatch(block -> {
-                    // If any blocking repo matches these predicates then continue validation
-                    // If no blocking repo matches then we can short circuit with no-cancellation
-                    if (!block.contains("/") && block.equals(repoPath.getRepoKey())) {
-                        return true;
-                    } else if (block.contains("/")) {
-                        // If block includes a branch, need to check against repo and path
-                        String wholePath = repoPath.toPath();
-                        // Not equal check since need to validate when block=repo/branch and repoAndPath=repo/branch/child
-                        String regex = "^" + block + "/.*";
-                        if (wholePath.matches(regex)) {
-                            return true;
-                        }
-                    }
-                    return false;
-                }))
+        // We are dealing with a file; check if that file is under a managed Docker Repo
+        // If under a managed Docker Repo this could be part of a 'docker pull' or an Artifactory download
+        moduleConfig.getBlockingDockerRepos().ifPresentOrElse(dockerRepos -> {
+            isManagedDockerRepo.set(dockerRepos.stream().anyMatch(block -> pathInManagedRepo.apply(block, repoPath)));
+        }, () -> isManagedDockerRepo.set(false));
+
+        // item is not part of a managed Docker Repo; check to see if it is part of a regular managed repo
+        if (!isManagedDockerRepo.get() && !moduleConfig.getBlockingRepos().stream()
+                .anyMatch(block -> pathInManagedRepo.apply(block, repoPath)))
         {
             return CancelDecision.NO_CANCELLATION();
         }
 
-        AtomicBoolean isBeforeCutoffTime = new AtomicBoolean(false);
-        moduleConfig.getCutoffDateString().ifPresent(cutoffDateString ->
-                {
-                    long cutoffTime = moduleConfig.getDateTimeManager().getTimeFromString(cutoffDateString);
-                    if (itemInfo.getLastUpdated() <= cutoffTime) {
-                        logger.info(String.format("Item last updated prior to cutoff time; No Blocking Strategy applied; repo: %s", repoPath));
-                        isBeforeCutoffTime.set(true);
+        if (!isManagedDockerRepo.get()) {
+            AtomicBoolean isBeforeCutoffTime = new AtomicBoolean(false);
+            moduleConfig.getCutoffDateString().ifPresent(cutoffDateString ->
+                    {
+                        long cutoffTime = moduleConfig.getDateTimeManager().getTimeFromString(cutoffDateString);
+                        if (itemInfo.getLastUpdated() <= cutoffTime) {
+                            logger.info(String.format("Item last updated prior to cutoff time; No Blocking Strategy applied; repo: %s", repoPath));
+                            isBeforeCutoffTime.set(true);
+                        }
                     }
-                }
-        );
-        if (isBeforeCutoffTime.get()) {
-            return CancelDecision.NO_CANCELLATION();
+            );
+            if (isBeforeCutoffTime.get()) {
+                return CancelDecision.NO_CANCELLATION();
+            }
         }
 
-        File file = new File(itemInfo.getName());
+        File file = (isManagedDockerRepo.get() ? null : new File(itemInfo.getName()));
         Optional<List<String>> allowedNamePatterns = moduleConfig.getAllowedFileNamePatterns();
         Optional<List<String>> excludedNamePatterns = moduleConfig.getExcludedFileNamePatterns();
 
-        if (applyBlockingStrategyBasedOnFilePattern(allowedNamePatterns.orElse(null), excludedNamePatterns.orElse(null), file)) {
+        // If this is Docker Repo, set the repoPath so annotations are read from the directory, not the file
+        RepoPath repoPathToImageTag = null;
+        if (isManagedDockerRepo.get()) {
+            // Get RepoPath for the directory used as the docker image tag
+            if (!itemInfo.isFolder()) {
+                int endIdx = itemInfo.getRelPath().lastIndexOf("/");
+                repoPathToImageTag = repoPathFactory.create(itemInfo.getRepoKey(),
+                        endIdx == -1 ? itemInfo.getRelPath() : itemInfo.getRelPath().substring(0, endIdx));
+            } else {
+                repoPathToImageTag = repoPath;
+            }
+        }
+        final RepoPath repoPathToQuery = isManagedDockerRepo.get() ? repoPathToImageTag : repoPath;
+
+        if (isManagedDockerRepo.get() || applyBlockingStrategyBasedOnFilePattern(allowedNamePatterns.orElse(null), excludedNamePatterns.orElse(null), file)) {
             ScanAsAServiceBlockingStrategy blockingStrategy = moduleConfig.getBlockingStrategy();
-            Optional<ProjectVersionComponentPolicyStatusType> policyViolationStatus = propertyService.getPolicyStatus(repoPath);
-            return propertyService.getScanStatusProperty(repoPath).map(
+            Optional<ProjectVersionComponentPolicyStatusType> policyViolationStatus = propertyService.getPolicyStatus(repoPathToQuery);
+            return propertyService.getScanStatusProperty(repoPathToQuery).map(
                             scanStatus -> {
                                 CancelDecision dec;
                                 switch (scanStatus) {
                                 case FAILED:
                                     switch (blockingStrategy) {
                                     case BLOCK_ALL:
-                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPathToQuery));
                                         break;
                                     case BLOCK_NONE:
-                                        logger.info("Download NOT blocked; Blocking Strategy: {}; {}; repo: {}", blockingStrategy, scanStatus.getMessage(), repoPath);
+                                        logger.info("Download NOT blocked; Blocking Strategy: {}; {}; repo: {}", blockingStrategy, scanStatus.getMessage(), repoPathToQuery);
                                         dec = CancelDecision.NO_CANCELLATION();
                                         break;
                                     case BLOCK_OFF:
                                         logger.info("Download NOT blocked; Blocking Strategy: {}; Download would have been blocked; {}; repo: {}",
-                                                ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), repoPath);
+                                                ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), repoPathToQuery);
                                         dec = CancelDecision.NO_CANCELLATION();
                                         break;
                                     default:
-                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPathToQuery));
                                     }
                                     break;
                                 case PROCESSING:
                                     switch (blockingStrategy) {
                                     case BLOCK_ALL:
-                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPath));
+                                        dec = CancelDecision.CANCEL_DOWNLOAD(String.format("Download blocked; %s; repo: %s", scanStatus.getMessage(), repoPathToQuery));
                                         break;
                                     case BLOCK_NONE:
                                         dec = CancelDecision.NO_CANCELLATION();
                                         break;
                                     case BLOCK_OFF:
                                         logger.info("Download NOT Blocked; Blocking Strategy: {}; {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF,
-                                                scanStatus.getMessage(), repoPath);
+                                                scanStatus.getMessage(), repoPathToQuery);
                                         dec = CancelDecision.NO_CANCELLATION();
                                         break;
                                     default:
                                         dec = CancelDecision.CANCEL_DOWNLOAD(
-                                                String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                                                String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPathToQuery));
                                     }
                                     break;
                                 case SUCCESS:
@@ -141,33 +187,33 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
                                         case IN_VIOLATION:
                                             if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
                                                 logger.info("Download NOT blocked; Blocking Strategy: {}; {}; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF,
-                                                        scanStatus.getMessage(), repoPath);
+                                                        scanStatus.getMessage(), repoPathToQuery);
                                                 dec = CancelDecision.NO_CANCELLATION();
                                             } else {
                                                 dec = CancelDecision.CANCEL_DOWNLOAD(
                                                         String.format("Download blocked; %s; Policy Violation Status: %s; repo: %s", scanStatus.getMessage(),
-                                                                policyViolationStatus.get(), repoPath));
+                                                                policyViolationStatus.get(), repoPathToQuery));
                                             }
                                             break;
                                         default:
                                             if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
                                                 logger.info("Download NOT blocked; Blocking Strategy: {}; {}; Unknown policy violation status: {}; repo: {}",
-                                                        ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), policyViolationStatus.get(), repoPath);
+                                                        ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus.getMessage(), policyViolationStatus.get(), repoPathToQuery);
                                                 dec = CancelDecision.NO_CANCELLATION();
                                             } else {
                                                 dec = CancelDecision.CANCEL_DOWNLOAD(
                                                         String.format("Download blocked; %s; Unknown policy violation status: %s; repo: %s",
-                                                                scanStatus.getMessage(), policyViolationStatus.get(), repoPath));
+                                                                scanStatus.getMessage(), policyViolationStatus.get(), repoPathToQuery));
                                             }
                                         }
                                     } else {
                                         logger.warn(String.format("%s; %s property not present; Using block strategy: %s; repo: %s", scanStatus.getMessage(),
-                                                BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS.getPropertyName(), blockingStrategy, repoPath));
+                                                BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS.getPropertyName(), blockingStrategy, repoPathToQuery));
                                         switch (blockingStrategy) {
                                         case BLOCK_ALL:
                                             dec = CancelDecision.CANCEL_DOWNLOAD(
                                                     String.format("Download blocked; %s; %s not present; block strategy: %s; repo: %s", scanStatus.getMessage(),
-                                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPathToQuery));
                                             break;
                                         case BLOCK_NONE:
                                         case BLOCK_OFF:
@@ -176,7 +222,7 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
                                         default:
                                             dec = CancelDecision.CANCEL_DOWNLOAD(
                                                     String.format("Download blocked; %s not present; Unknown blocking strategy: %s; repo: %s",
-                                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPath));
+                                                            BlackDuckArtifactoryProperty.OVERALL_POLICY_STATUS, blockingStrategy, repoPathToQuery));
                                         }
                                     }
                                     break;
@@ -184,11 +230,11 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
                                     logger.warn(String.format("Unknown scan status detected: %s", scanStatus));
                                     if (ScanAsAServiceBlockingStrategy.BLOCK_OFF == blockingStrategy) {
                                         logger.info("Download NOT blocked; Blocking Strategy: {}; Unknown ScanStatusProperty: {}; repo: {}",
-                                                ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus, repoPath);
+                                                ScanAsAServiceBlockingStrategy.BLOCK_OFF, scanStatus, repoPathToQuery);
                                         dec = CancelDecision.NO_CANCELLATION();
                                     } else {
                                         dec = CancelDecision.CANCEL_DOWNLOAD(
-                                                String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", scanStatus, repoPath));
+                                                String.format("Download blocked; Unknown ScanStatusProperty: %s; repo: %s", scanStatus, repoPathToQuery));
                                     }
                                 }
                                 return dec;
@@ -197,20 +243,20 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
                         switch (blockingStrategy) {
                         case BLOCK_ALL:
                             return CancelDecision.CANCEL_DOWNLOAD(
-                                    String.format("Download blocked; Scan not scheduled and blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                                    String.format("Download blocked; Scan not scheduled and blocking strategy: %s; repo: %s", blockingStrategy, repoPathToQuery));
                         case BLOCK_NONE:
                             return CancelDecision.NO_CANCELLATION();
                         case BLOCK_OFF:
                             logger.info("Download NOT blocked; Blocking Strategy: {}; Scan not scheduled; repo: {}", ScanAsAServiceBlockingStrategy.BLOCK_OFF,
-                                    repoPath);
+                                    repoPathToQuery);
                             return CancelDecision.NO_CANCELLATION();
                         default:
                             return CancelDecision.CANCEL_DOWNLOAD(
-                                    String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPath));
+                                    String.format("Download blocked; Unknown blocking strategy: %s; repo: %s", blockingStrategy, repoPathToQuery));
                         }
                     });
         } else {
-            logger.info("Download NOT blocked; File allowed/excluded pattern check failed; repo: {}", repoPath);
+            logger.info("Download NOT blocked; File allowed/excluded pattern check failed; repo: {}", repoPathToQuery);
             return CancelDecision.NO_CANCELLATION();
         }
     }
@@ -231,6 +277,11 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
         AtomicBoolean awcm = new AtomicBoolean(false);
         AtomicBoolean ewcp = new AtomicBoolean(false);
         AtomicBoolean ewcm = new AtomicBoolean(false);
+
+        if (file == null) {
+            logger.debug("File: NULL; Cannot determine if file patterns apply");
+            return false;
+        }
 
         Optional<WildcardFileFilter> allowedWildCardFilter = Optional.ofNullable(allowedPatterns == null ? null : new WildcardFileFilter(allowedPatterns));
         Optional<WildcardFileFilter> excludedWildCardFilter = Optional.ofNullable(excludedPatterns == null ? null : new WildcardFileFilter(excludedPatterns));
@@ -270,5 +321,21 @@ public class ScanAsAServiceCancelDecider implements CancelDecider {
         logger.debug("File: [{}]; Allowed Filter Evaluated: [{}]; Allowed Filter Matched: [{}]; Exclude Filter Evaluated: [{}]; Exclude Filter Matched: [{}]; Return Value: [{}]",
                 file.getName(), awcp, awcm, ewcp, ewcm, ret);
         return ret.get();
+    }
+
+    private static String displayItemInfo(ItemInfo item) {
+        return MoreObjects.toStringHelper(ItemInfo.class)
+                .omitNullValues()
+                .add("repoPath", item.getRepoPath())
+                .add("isFolder", item.isFolder())
+                .add("name", item.getName())
+                .add("repoKey", item.getRepoKey())
+                .add("relPath", item.getRelPath())
+                .add("created", item.getCreated())
+                .add("lastModified", item.getLastModified())
+                .add("modifiedBy", item.getModifiedBy())
+                .add("createdBy", item.getCreatedBy())
+                .add("lastUpdate", item.getLastUpdated())
+                .toString();
     }
 }


### PR DESCRIPTION
For repos of type Docker that are configured to be managed (ie in the `blackduck.artifactory.scaaas.blocking.docker.repos` list), apply the blocking strategy when a `docker pull` is performed. Also apply the blocking strategy when uses try to download files directly (either via the UI or curl).